### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/known-issue---limitation.md
+++ b/.github/ISSUE_TEMPLATE/known-issue---limitation.md
@@ -1,0 +1,25 @@
+---
+name: Known Issue / Limitation
+about: Used by Reboot maintainers to document known issues, and known limitations
+title: ''
+labels: Known Issue or Limitation
+assignees: ''
+
+---
+
+## What is the limitation?
+Explain in clear language what Reboot currently can't do. Assume that the reader is not yet deeply familiar with Reboot.
+
+## How do I know if I've hit this limitation?
+Explain the tell-tale signs that are visible when a developer hits this limitation during Reboot development. Ideally, this part of the description is highly Google-able - make sure to use the keywords and/or error messages that a developer would search for when they encounter this issue.
+
+## What do I do if I've hit this limitation?
+### 1. Send feedback!
+Please comment below, and share your use-case! We prioritize work based on user feedback, so letting us know that this limitation is affecting you, and why, helps us get the most important issues dealt with first!
+
+### 2. Consider solutions or workarounds
+#### [Workaround/solution 1 title]
+Offer the least disruptive workaround or solution first.
+
+#### [Workaround/solution N title]
+Offer any additional more-disruptive workarounds or solutions for developers that can't use the earlier ones.


### PR DESCRIPTION
By having issue templates, especially for the `Known Issue / Limitation` category, we'll create a consistent issue tracking experience.

We use GitHub's default `Bug report` and `Feature request` templates, and add our own for `Known Issue / Limitation`, based off https://github.com/reboot-dev/reboot/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen

Issue templates can be edited [using GitHub's web interface](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-templates), but are stored in our repo. 