### PR TITLE
Fix broken docs link in missing-authorization warning

### DIFF
--- a/reboot/aio/auth/authorizers.py
+++ b/reboot/aio/auth/authorizers.py
@@ -390,7 +390,7 @@ class DefaultAuthorizer(Authorizer[Message | Model, Message | Model | None]):
                 f"*** {self._state_name}.{method_name.split('.')[-1]} IS "
                 "MISSING AUTHORIZATION *** Calls to this method are ONLY "
                 "ALLOWED during development and will be DENIED in "
-                f"production. See {DOCS_BASE_URL}/develop/auth#default-authorizer "
+                f"production. See {DOCS_BASE_URL}/learn_more/auth#default-authorizer "
                 "for more details. Will silence this message for the next 1 "
                 "minute."
             )


### PR DESCRIPTION
The old link https://docs.reboot.dev/develop/auth#default-authorizer 404s since the docs rename in commit d1c45c8. The new link https://docs.reboot.dev/learn_more/auth/#default-authorizer is verified working (HTTP 200).

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)