### PR TITLE
Bugfix: workflow transactions recovered before commit were not exactly-once

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -137,6 +137,15 @@ jobs:
           # the exchange; the job's `pull-requests: write` is all the
           # inline comments need.
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Aviator drives our merge queue and pushes to a pull request
+          # when it rebases the branch, firing a `synchronize` event
+          # whose actor is `aviator-app[bot]`. The action refuses to run
+          # for a non-human actor unless it is named here, so a review
+          # triggered by a rebase failed outright and left the queue
+          # blocked. Name our own merge-queue app rather than `*`, which
+          # would let any GitHub App that can trigger this workflow
+          # spend our Anthropic API budget.
+          allowed_bots: "aviator-app"
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           # Pass `--comment` so findings post as inline PR comments;

--- a/reboot/aio/state_managers.py
+++ b/reboot/aio/state_managers.py
@@ -4762,7 +4762,17 @@ class SidecarStateManager(
             for transaction in self._lookup_participant_transactions(
                 state_type_name, state_ref
             ).values():
-                if transaction.idempotency_key == context.idempotency_key:
+                if (
+                    transaction.idempotency_key == context.idempotency_key or
+                    # A prepared transaction recovered after a restart
+                    # has `idempotency_key == None`, but its recovered
+                    # uncommitted idempotent mutations are keyed by the
+                    # idempotency keys of the calls that produced them,
+                    # including the transaction's own, so a key match
+                    # means this call is a duplicate of that
+                    # transaction.
+                    context.idempotency_key in transaction.idempotent_mutations
+                ):
                     await transaction
                     break
 
@@ -6023,13 +6033,19 @@ class SidecarStateManager(
                     # users can tradeoff performance for better error
                     # detection of their own code).
                     if len(transaction.idempotent_mutations) > 0:
-                        # Invariant here is that if this transaction
-                        # includes idempotent mutations then we should
-                        # have already recovered them from the
-                        # database (we'll get a `KeyError` here if
-                        # this invariant is broken).
-                        self._idempotent_mutations[state_type][
-                            state_ref].update(
+                        # A transaction that executed on this server
+                        # has always populated this cache entry via
+                        # `check_for_idempotent_mutation()`, but a
+                        # transaction recovered after a restart
+                        # commits without any prior lookup, so the
+                        # entry may be absent. In that case skipping
+                        # the update is safe: any later lookup
+                        # recovers from the database, which as of the
+                        # commit above includes these mutations.
+                        idempotent_mutations = self._idempotent_mutations[
+                            state_type].get(state_ref)
+                        if idempotent_mutations is not None:
+                            idempotent_mutations.update(
                                 transaction.idempotent_mutations
                             )
 

--- a/reboot/server/database.cc
+++ b/reboot/server/database.cc
@@ -3614,8 +3614,6 @@ grpc::Status DatabaseService::RecoverTransactionIdempotentMutations(
   std::unique_ptr<rocksdb::WBWIIterator> iterator(
       CHECK_NOTNULL(batch->NewIterator(*column_family_handle)));
 
-  iterator->Seek(rocksdb::Slice(IDEMPOTENT_MUTATION_KEY_PREFIX));
-
   // When iterating via the transaction's write batch directly we get
   // `rocksdb::WriteEntry`s which may exist for the same key multiple
   // times. In the case of an idempotent mutation, we never expect it
@@ -3623,36 +3621,49 @@ grpc::Status DatabaseService::RecoverTransactionIdempotentMutations(
   // each idempotency key we find in a set.
   std::set<std::string> idempotency_keys;
 
-  while (iterator->Valid()) {
-    rocksdb::WriteEntry entry = iterator->Entry();
+  // Idempotent mutations are stored under a scope-specific key
+  // prefix (see `MakeIdempotentMutationKey`), so we scan the write
+  // batch once per prefix.
+  for (const std::string_view prefix : {
+           std::string_view(IDEMPOTENT_MUTATION_KEY_PREFIX),
+           std::string_view(EXPIRING_IDEMPOTENT_MUTATION_KEY_PREFIX),
+           std::string_view(WORKFLOW_IDEMPOTENT_MUTATION_KEY_PREFIX),
+           std::string_view(WORKFLOW_EXPIRING_IDEMPOTENT_MUTATION_KEY_PREFIX),
+           std::string_view(WORKFLOW_ITERATION_IDEMPOTENT_MUTATION_KEY_PREFIX),
+       }) {
+    iterator->Seek(rocksdb::Slice(prefix.data(), prefix.size()));
 
-    // Make sure this is still a key we care about.
-    if (entry.key.ToStringView().find(IDEMPOTENT_MUTATION_KEY_PREFIX) != 0) {
-      break;
+    while (iterator->Valid()) {
+      rocksdb::WriteEntry entry = iterator->Entry();
+
+      // Make sure this is still a key we care about.
+      if (entry.key.ToStringView().find(prefix) != 0) {
+        break;
+      }
+
+      // We are only expecting idempotent mutations to be inserted into
+      // the database during a transaction.
+      CHECK_EQ(entry.type, rocksdb::kPutRecord);
+
+      IdempotentMutation idempotent_mutation;
+
+      CHECK(idempotent_mutation.ParseFromArray(
+          entry.value.data(),
+          entry.value.size()));
+
+      // Idempotent mutation should be for this transaction's state ref!
+      CHECK_EQ(idempotent_mutation.state_type(), transaction.state_type());
+      CHECK_EQ(idempotent_mutation.state_ref(), transaction.state_ref());
+
+      CHECK(idempotency_keys.count(idempotent_mutation.key()) == 0);
+
+      idempotency_keys.insert(idempotent_mutation.key());
+
+      *transaction.add_uncommitted_idempotent_mutations() =
+          std::move(idempotent_mutation);
+
+      iterator->Next();
     }
-
-    // We are only expecting idempotent mutations to be inserted into
-    // the database during a transaction.
-    CHECK_EQ(entry.type, rocksdb::kPutRecord);
-
-    IdempotentMutation idempotent_mutation;
-
-    CHECK(idempotent_mutation.ParseFromArray(
-        entry.value.data(),
-        entry.value.size()));
-
-    // Idempotent mutation should be for this transaction's state ref!
-    CHECK_EQ(idempotent_mutation.state_type(), transaction.state_type());
-    CHECK_EQ(idempotent_mutation.state_ref(), transaction.state_ref());
-
-    CHECK(idempotency_keys.count(idempotent_mutation.key()) == 0);
-
-    idempotency_keys.insert(idempotent_mutation.key());
-
-    *transaction.add_uncommitted_idempotent_mutations() =
-        std::move(idempotent_mutation);
-
-    iterator->Next();
   }
 
   return grpc::Status::OK;

--- a/tests/reboot/tasks_tests.py
+++ b/tests/reboot/tasks_tests.py
@@ -17,6 +17,7 @@ from reboot.aio.internals.tasks_cache import (
     TASKS_RESPONSES_CACHE_TARGET_CAPACITY,
 )
 from reboot.aio.internals.tasks_dispatcher import TasksDispatcher
+from reboot.aio.state_managers import SidecarStateManager
 from reboot.aio.tests import Reboot
 from reboot.aio.types import StateRef
 from reboot.aio.workflows import until_changes
@@ -1330,6 +1331,192 @@ class TasksTestCase(unittest.IsolatedAsyncioTestCase):
         # mutations and thus not run them again.
         self.assertEqual(writer_call_count, 1)
         self.assertEqual(transaction_call_count, 1)
+
+    async def test_workflow_transaction_uncommitted_at_failure_survives_recovery(
+        self,
+    ) -> None:
+        """Test that a workflow's transaction whose two phase commit
+        was durably prepared but whose commit had not yet become
+        durable at the time of a failure is executed exactly once: on
+        recovery the transaction is recovered as prepared and
+        committed, and the workflow's re-executed call must reuse its
+        response rather than execute the transaction again.
+
+        A transaction's response is returned to its caller once all
+        participants have durably prepared, while the commit becomes
+        durable asynchronously. To make this interleaving
+        deterministic we block every participant commit on an event
+        that we only set once `rbt.down()`, `rbt.up()`, and the
+        re-executed workflow's duplicate transaction call reaching
+        its idempotency check have all happened. The application and
+        its state managers run in the test's own process and event
+        loop, so `asyncio.Event`s and `mock.patch` reach them
+        directly.
+        """
+        # Every `transaction_participant_commit()` blocks on this
+        # event, so the transaction is uncommitted when `rbt.down()`
+        # happens and the recovered transaction is still pending
+        # while the duplicate call checks idempotency.
+        proceed_with_commit = asyncio.Event()
+
+        # Set when the re-executed workflow's duplicate transaction
+        # call after recovery reaches its idempotency check.
+        transaction_reattempted = asyncio.Event()
+
+        # Set by the test once `rbt.down()` has happened, so that
+        # only post-recovery idempotency checks signal
+        # `transaction_reattempted`.
+        recovered = False
+
+        transaction_participant_commit = (
+            SidecarStateManager.transaction_participant_commit
+        )
+
+        async def blocked_transaction_participant_commit(
+            state_manager: SidecarStateManager,
+            transaction,
+        ):
+            await proceed_with_commit.wait()
+            return await transaction_participant_commit(
+                state_manager, transaction
+            )
+
+        check_for_idempotent_mutation = (
+            SidecarStateManager.check_for_idempotent_mutation
+        )
+
+        async def observed_check_for_idempotent_mutation(
+            state_manager: SidecarStateManager,
+            context,
+        ):
+            if recovered and isinstance(context, TransactionContext):
+                transaction_reattempted.set()
+            return await check_for_idempotent_mutation(state_manager, context)
+
+        writer_and_transaction_called = asyncio.Event()
+        proceed_after_down = asyncio.Event()
+
+        writer_call_count = 0
+        transaction_call_count = 0
+
+        class TestServicer(GeneralServicer):
+
+            def authorizer(self):
+                return allow()
+
+            async def constructor_writer(
+                self,
+                context: WriterContext,
+                state: General.State,
+                request: GeneralRequest,
+            ) -> GeneralResponse:
+                return GeneralResponse()
+
+            async def writer(
+                self,
+                context: WriterContext,
+                state: General.State,
+                request: GeneralRequest,
+            ) -> GeneralResponse:
+                nonlocal writer_call_count
+                writer_call_count += 1
+                return GeneralResponse()
+
+            async def transaction(
+                self,
+                context: TransactionContext,
+                state: General.State,
+                request: GeneralRequest,
+            ) -> GeneralResponse:
+                nonlocal transaction_call_count
+                transaction_call_count += 1
+                return GeneralResponse()
+
+            @classmethod
+            async def workflow(
+                cls,
+                context: WorkflowContext,
+                request: GeneralRequest,
+            ) -> GeneralResponse:
+                g = General.ref()
+
+                # Make writer and transaction calls which are
+                # idempotent by default.
+                await g.writer(context)
+                await g.transaction(context)
+
+                # Signal that both have been called.
+                writer_and_transaction_called.set()
+
+                # Wait until the test tells us to proceed (after
+                # `rbt.down()`/`rbt.up()`).
+                await proceed_after_down.wait()
+
+                return GeneralResponse()
+
+        with mock.patch(
+            'reboot.aio.state_managers.SidecarStateManager'
+            '.transaction_participant_commit',
+            blocked_transaction_participant_commit,
+        ), mock.patch(
+            'reboot.aio.state_managers.SidecarStateManager'
+            '.check_for_idempotent_mutation',
+            observed_check_for_idempotent_mutation,
+        ):
+            revision = await self.rbt.up(
+                Application(servicers=[TestServicer]),
+                # Need to disable effect validation because this test
+                # relies on setting some nonlocal variables.
+                effect_validation=EffectValidation.DISABLED,
+            )
+
+            context = self.rbt.create_external_context(name=self.id())
+
+            # Construct.
+            g, _ = await General.constructor_writer(context)
+
+            # Spawn the workflow.
+            task = await g.spawn().workflow(context)
+
+            # Wait for both mutations to be called.
+            await writer_and_transaction_called.wait()
+
+            self.assertEqual(writer_call_count, 1)
+            self.assertEqual(transaction_call_count, 1)
+
+            # Simulate failure. The transaction's commit is blocked
+            # on `proceed_with_commit` so the transaction is durably
+            # prepared but uncommitted.
+            await self.rbt.down()
+
+            # Reset events for the re-run after recovery.
+            writer_and_transaction_called.clear()
+
+            recovered = True
+
+            await self.rbt.up(revision=revision)
+
+            # Wait for the re-executed workflow's duplicate
+            # transaction call to reach its idempotency check while
+            # the recovered transaction is still pending, then let
+            # the recovered transaction commit.
+            await transaction_reattempted.wait()
+            proceed_with_commit.set()
+
+            # Let the workflow proceed to completion.
+            proceed_after_down.set()
+
+            await task
+
+            # We should have tried to call both mutations again.
+            await writer_and_transaction_called.wait()
+
+            # But they still should only have been called once even
+            # after recovery because the workflow's re-executed calls
+            # must reuse the recovered mutations, including the
+            # transaction's, which only commits during recovery.
+            self.assertEqual(writer_call_count, 1)
+            self.assertEqual(transaction_call_count, 1)
 
     async def test_control_loop_per_iteration_idempotency_survives_recovery(
         self,


### PR DESCRIPTION
Before this fix, with a failure at the wrong time, a workflow's idempotent transaction call executed — and commits — twice. Discovered by a flaky test: `tasks_tests_py::TasksTestCase.test_workflow_idempotent_writer_and_transaction_survive_recovery` was flaky ever since it was written, and pointed us to this real bug.

The race was as follows:

1. A workflow calls a transaction with an idempotency key. The transaction's response returns to the workflow as soon as two-phase commit's **prepare** is durable everywhere; the **commit** becomes durable asynchronously (via the coordinator's commit control loop and/or the participant's watch task, both funneling into `SidecarStateManager.transaction_participant_commit`).
2. The application goes down inside that window (in the test, `rbt.down()` cancels the pending commit tasks), leaving the transaction durably prepared but uncommitted — its idempotent-mutation record (key → response) persisted only *inside* the prepared transaction.
3. On restart, recovery registers the prepared transaction and finishes its commit in the background — while the recovered workflow re-executes concurrently. The workflow's duplicate transaction call runs `check_for_idempotent_mutation()` before that commit lands: the committed-mutations lookup misses, and the in-flight-transaction guard (reboot-dev/mono#5361) misses too, so the call starts a **new** transaction, waits behind the recovered transaction's exclusive lock, and re-executes the user's transaction method after the recovered one commits.

In practice this bug is rare to see, because the prepared transaction being recovered typically completes its commit before the workflow re-executes - so the test usually passes. It's possible however for the workflow re-execution to win, in which case the transaction effects occur twice. 😬

There are _two_ bugs that combined to produce this race:

1. C++: `DatabaseService::RecoverTransactionIdempotentMutations` scanned a recovered transaction's write batch only under the `idempotent-mutation-v4` key prefix. Commit db327a7a8 moved workflow-scoped mutations under `workflow-idempotent-mutation*` key prefixes and updated `Store`, `Export`, and `RecoverIdempotentMutations` accordingly — but not `RecoverTransactionIdempotentMutations`. A recovered prepared transaction therefore reported empty `uncommitted_idempotent_mutations` for workflow calls. That same commit also *introduced the flaky test*, so the flake has existed since this code was written.
2. Python: the fix we made for reboot-dev/mono#5361 in `check_for_idempotent_mutation()` matches only `transaction.idempotency_key`, which is never persisted and is therefore `None` for a recovered transaction.

Fixes:

- `reboot/server/database.cc`: scan the write batch once per idempotent-mutation key prefix (plain, expiring, and the three workflow-scoped ones) so a recovered prepared transaction knows **all** of its uncommitted idempotent mutations.
- `reboot/aio/state_managers.py`: the in-flight guard also matches `context.idempotency_key in transaction.idempotent_mutations`; a duplicate call then awaits the recovered transaction and serves its cached response.
- `reboot/aio/state_managers.py`: `transaction_participant_commit` now tolerates the per-state idempotent-mutations cache entry being absent — possible once recovered transactions carry idempotent mutations and commit before any call has touched that state — instead of raising `KeyError` in the exception-intolerant commit section. Skipping the update is safe: any later lookup recovers from the database, which at that point includes the committed mutations.
- `tests/reboot/tasks_tests.py`: new deterministic regression test.

This ports reboot-dev/mono#5617 to the public repo.
