### PR TITLE
OAuth: deliver identity provider claims to `User` state via `SetClaims`

### DIFF
--- a/reboot/aio/applications.py
+++ b/reboot/aio/applications.py
@@ -9,7 +9,6 @@ import reboot.aio.workflows
 import reboot.application
 import sys
 import traceback
-from collections import OrderedDict
 from log.log import get_logger
 from mcp.server.fastmcp import FastMCP
 from pathlib import Path
@@ -66,17 +65,12 @@ from reboot.settings import (
 from reboot.version import REBOOT_VERSION
 from reboot.versioning import version_less_than
 from starlette.staticfiles import StaticFiles
-from typing import Any, Awaitable, Callable, NoReturn, Optional
+from typing import Any, Awaitable, Callable, Mapping, NoReturn, Optional
 from urllib.parse import urlparse
 
 logger = get_logger(__name__)
 
 _MCP_PATH = "/mcp"
-
-# Cap on the per-instance cache of user ids that `_authenticated`
-# has already handled. Eviction is harmless: the next JWT mint for an
-# evicted user re-runs the idempotent auto-construct calls.
-_AUTHENTICATED_USER_IDS_LIMIT = 16_384
 
 
 def _handle_unknown_exception(
@@ -438,12 +432,6 @@ class Application:
         self._initialize_bearer_token = initialize_bearer_token
         self._oauth = oauth
         self._oauth_server: Optional[OAuthServer] = None
-        # Bounded LRU (keys only; values are a placeholder `None`) of
-        # users for whom `_authenticated` has already run. Kept
-        # per-instance rather than on the class so a fresh `Reboot()` +
-        # state store per test method doesn't inherit a stale "already
-        # authenticated" flag from a sibling test.
-        self._authenticated_user_ids: OrderedDict[str, None] = (OrderedDict())
         # `allowed_origins=None` (the default) is meaningfully
         # distinct from `allowed_origins=[]` (an explicit choice).
         # The default tells us the developer hasn't thought about
@@ -811,46 +799,38 @@ class Application:
         self,
         context: ExternalContext,
         user_id: str,
+        claims: Optional[Mapping[str, Any]] = None,
     ) -> None:
-        """Materialize per-user auto-construct state the first time a
-        user authenticates. Safe and cheap to call again for the same
-        user.
+        """Record that a user authenticated: materialize their
+        per-user auto-construct state if it does not exist yet, then,
+        when `claims` is given, deliver their verified identity
+        claims. Safe and cheap to call again for the same user.
 
-        `context` is app-internal: materializing the state is a Writer
-        call (`User.Create(...)`) that the authorizer permits from
-        trusted app code (auto-construct `User` types allow
-        app-internal callers).
+        Runs on every mint, so it re-delivers `claims` on every
+        sign-in rather than deduplicating: `claims=None` (a refresh,
+        which has no fresh claims) still ensures the state exists,
+        while a code exchange re-delivers so state converges on the
+        most recently delivered claims (an A -> B -> A email change
+        ends at A). Both the construct (keyed on the state id) and
+        `set_claims` (a full replace) are idempotent, so repeating
+        them is cheap and correct.
+
+        `context` is app-internal: materializing and updating the
+        state are Writer/Transaction calls that the framework permits
+        only from trusted app code, since claims ride the delivery.
         """
-        # Idempotent across both calls and processes: an instance-
-        # level cache makes repeat hits free within one `Application`
-        # lifetime, and Reboot's storage-layer idempotency makes the
-        # construct durable across processes. The cache is
-        # deliberately a per-instance attribute, not a class
-        # attribute, so a fresh `Reboot()` + state store per test
-        # method doesn't inherit a stale "already authenticated" flag
-        # from a sibling test.
-        if user_id in self._authenticated_user_ids:
-            self._authenticated_user_ids.move_to_end(user_id)
-            return
         # Fan out across all auto-construct servicers in parallel —
         # every JWT mint blocks on this, so a serial loop would add N
-        # RPC RTTs to first-time sign-in for an app with N auto-
-        # construct state types.
+        # RPC RTTs to sign-in for an app with N auto-construct state
+        # types.
         await asyncio.gather(
             *(
-                servicer_cls._authenticated(context, state_id=user_id)
+                servicer_cls.
+                _authenticated(context, state_id=user_id, claims=claims)
                 for servicer_cls in (self._servicers or [])
                 if servicer_cls._is_auto_construct
             )
         )
-        self._authenticated_user_ids[user_id] = None
-        # Evict least-recently-authenticated entries beyond the cap; an
-        # evicted user's next mint just redoes the (idempotent, cheap)
-        # auto-construct calls.
-        while (
-            len(self._authenticated_user_ids) > _AUTHENTICATED_USER_IDS_LIMIT
-        ):
-            self._authenticated_user_ids.popitem(last=False)
 
     def _mount_mcp(
         self,

--- a/reboot/aio/applications.py
+++ b/reboot/aio/applications.py
@@ -73,10 +73,10 @@ logger = get_logger(__name__)
 
 _MCP_PATH = "/mcp"
 
-# Cap on the per-instance cache of user ids that `_post_authenticate`
+# Cap on the per-instance cache of user ids that `_authenticated`
 # has already handled. Eviction is harmless: the next JWT mint for an
 # evicted user re-runs the idempotent auto-construct calls.
-_POST_AUTHENTICATED_USER_IDS_LIMIT = 16_384
+_AUTHENTICATED_USER_IDS_LIMIT = 16_384
 
 
 def _handle_unknown_exception(
@@ -439,12 +439,11 @@ class Application:
         self._oauth = oauth
         self._oauth_server: Optional[OAuthServer] = None
         # Bounded LRU (keys only; values are a placeholder `None`) of
-        # users for whom `_post_authenticate` has already run. Kept
+        # users for whom `_authenticated` has already run. Kept
         # per-instance rather than on the class so a fresh `Reboot()` +
         # state store per test method doesn't inherit a stale "already
         # authenticated" flag from a sibling test.
-        self._post_authenticated_user_ids: OrderedDict[str,
-                                                       None] = (OrderedDict())
+        self._authenticated_user_ids: OrderedDict[str, None] = (OrderedDict())
         # `allowed_origins=None` (the default) is meaningfully
         # distinct from `allowed_origins=[]` (an explicit choice).
         # The default tells us the developer hasn't thought about
@@ -790,7 +789,7 @@ class Application:
                 auto_construct_state_type_full_names=(
                     auto_construct_state_type_full_names
                 ),
-                post_authenticate=self._post_authenticate,
+                authenticated=self._authenticated,
                 allowed_origins=self._allowed_origins,
             )
             self._oauth_server = oauth_server
@@ -808,7 +807,7 @@ class Application:
             oauth_server.mount_routes(self.http)
         return auto_construct_state_type_full_names
 
-    async def _post_authenticate(
+    async def _authenticated(
         self,
         context: ExternalContext,
         user_id: str,
@@ -830,8 +829,8 @@ class Application:
         # attribute, so a fresh `Reboot()` + state store per test
         # method doesn't inherit a stale "already authenticated" flag
         # from a sibling test.
-        if user_id in self._post_authenticated_user_ids:
-            self._post_authenticated_user_ids.move_to_end(user_id)
+        if user_id in self._authenticated_user_ids:
+            self._authenticated_user_ids.move_to_end(user_id)
             return
         # Fan out across all auto-construct servicers in parallel —
         # every JWT mint blocks on this, so a serial loop would add N
@@ -839,20 +838,19 @@ class Application:
         # construct state types.
         await asyncio.gather(
             *(
-                servicer_cls._auto_construct(context, state_id=user_id)
+                servicer_cls._authenticated(context, state_id=user_id)
                 for servicer_cls in (self._servicers or [])
                 if servicer_cls._is_auto_construct
             )
         )
-        self._post_authenticated_user_ids[user_id] = None
+        self._authenticated_user_ids[user_id] = None
         # Evict least-recently-authenticated entries beyond the cap; an
         # evicted user's next mint just redoes the (idempotent, cheap)
         # auto-construct calls.
         while (
-            len(self._post_authenticated_user_ids)
-            > _POST_AUTHENTICATED_USER_IDS_LIMIT
+            len(self._authenticated_user_ids) > _AUTHENTICATED_USER_IDS_LIMIT
         ):
-            self._post_authenticated_user_ids.popitem(last=False)
+            self._authenticated_user_ids.popitem(last=False)
 
     def _mount_mcp(
         self,

--- a/reboot/aio/auth/oauth_providers.py
+++ b/reboot/aio/auth/oauth_providers.py
@@ -19,7 +19,7 @@ from reboot.crypto import root_keys
 from reboot.run_environments import running_rbt_dev
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
-from typing import Any, NewType, Optional
+from typing import Any, Mapping, NewType, Optional, Sequence
 from ulid import ULID
 from urllib.parse import urlencode, urlparse, urlunparse
 
@@ -41,6 +41,18 @@ class ExchangeResult:
     # constructed with `store_tokens=True`; `None` otherwise, so apps
     # that don't opt in never carry these secrets around.
     tokens: Optional[OAuthTokens]
+    # The user's verified identity claims — the claims the provider
+    # was constructed to deliver (`claims=`), keyed by their presented
+    # names, as JSON-serializable values. Only claims from a verified
+    # source belong here: an ID token received directly from the
+    # provider's token endpoint over TLS, or the provider's userinfo
+    # endpoint over TLS. A mapping — even an empty one — is the
+    # complete, current verified claim set and is delivered as a full
+    # replacement, so an empty mapping clears previously delivered
+    # claims. `None` means claim delivery is off — the provider was
+    # constructed without `claims=` or has no verified claims source —
+    # and delivers nothing.
+    claims: Optional[Mapping[str, Any]] = None
 
 
 def _expires_at_from_expires_in(expires_in: Any) -> Optional[int]:
@@ -87,14 +99,130 @@ class OAuthProvider(ABC):
     Base class for identity providers.
     """
 
+    # The identity claims this provider can deliver: each available
+    # claim name, mapped to the OAuth scope that makes the identity
+    # provider include it (`None` when no scope is needed). Subclasses
+    # with a verified claims source override this.
+    _AVAILABLE_CLAIMS: Mapping[str, Optional[str]] = {}
+
     def __init__(
         self,
         *,
         access_token_ttl_seconds: int = _DEFAULT_ACCESS_TOKEN_TTL_SECONDS,
+        # The identity claims to deliver to the application on every
+        # sign-in: a sequence of claim names from this provider's
+        # available claims, or a mapping when a claim should be
+        # presented to the application under a different name (e.g.
+        # `{"email": "verified-email"}` delivers the provider's
+        # `email` claim as `verified-email`). `None` — the default —
+        # turns claim delivery off entirely. Requesting a claim this
+        # provider cannot deliver raises immediately, naming the
+        # available claims.
+        claims: Optional[Sequence[str] | Mapping[str, str]] = None,
     ):
         # How long minted access tokens are valid, in
         # seconds.
         self.access_token_ttl_seconds = access_token_ttl_seconds
+        # The requested identity claims, normalized to a mapping of
+        # source claim name to presented claim name; `None` when no
+        # claims were requested.
+        self._claims = self._normalized_claims(claims)
+
+    def _normalized_claims(
+        self,
+        claims: Optional[Sequence[str] | Mapping[str, str]],
+    ) -> Optional[dict[str, str]]:
+        """Validate a `claims=` argument against this provider's
+        available claims and normalize it to a mapping of source claim
+        name to presented claim name; `None` (also for an empty
+        `claims=`) means no claims were requested.
+        """
+        if claims is None:
+            return None
+        if isinstance(claims, str):
+            raise InputError(
+                reason=(
+                    f"`{type(self).__name__}` got `claims={claims!r}`: "
+                    "pass a sequence of claim names (e.g. "
+                    f"`claims=[{claims!r}]`) or a mapping of source "
+                    "claim name to presented claim name."
+                ),
+            )
+        if isinstance(claims, Mapping):
+            entries = list(claims.items())
+        else:
+            entries = [(name, name) for name in claims]
+        for name, presented in entries:
+            if not isinstance(name, str) or not isinstance(presented, str):
+                raise InputError(
+                    reason=(
+                        f"`{type(self).__name__}` got `claims=` "
+                        "containing a non-string entry "
+                        f"({name!r}: {presented!r}); claim names and "
+                        "presented names are strings."
+                    ),
+                )
+        normalized = dict(entries)
+        if not normalized:
+            return None
+        unknown = [
+            name for name in normalized if name not in self._AVAILABLE_CLAIMS
+        ]
+        if unknown:
+            unknown_list = ", ".join(f"'{name}'" for name in unknown)
+            if not self._AVAILABLE_CLAIMS:
+                raise InputError(
+                    reason=(
+                        f"`{type(self).__name__}` does not deliver "
+                        "identity claims; remove `claims=` "
+                        f"({unknown_list} requested)."
+                    ),
+                )
+            available_list = ", ".join(
+                f"'{name}'" for name in self._AVAILABLE_CLAIMS
+            )
+            raise InputError(
+                reason=(
+                    f"`{type(self).__name__}` cannot deliver the "
+                    f"identity claim(s) {unknown_list}; available "
+                    f"claims: {available_list}."
+                ),
+            )
+        presented_names = list(normalized.values())
+        if len(set(presented_names)) != len(presented_names):
+            duplicates = ", ".join(
+                f"'{name}'" for name in sorted(
+                    {
+                        name for name in presented_names
+                        if presented_names.count(name) > 1
+                    }
+                )
+            )
+            raise InputError(
+                reason=(
+                    f"`{type(self).__name__}` got `claims=` presenting "
+                    f"multiple claims under the same name: {duplicates}."
+                ),
+            )
+        return normalized
+
+    def _presented_claims(
+        self,
+        source: Mapping[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        """The requested identity claims present in `source` (a
+        decoded OIDC ID token, a userinfo response, ...), keyed by
+        their presented names; claims absent from `source` (or
+        `None`-valued there) are omitted. `None` when this provider
+        was constructed without `claims=`.
+        """
+        if self._claims is None:
+            return None
+        return {
+            presented: source[name]
+            for name, presented in self._claims.items()
+            if source.get(name) is not None
+        }
 
     @abstractmethod
     def authorization_url(
@@ -199,9 +327,13 @@ class RegisteredOAuthProvider(OAuthProvider):
         # default — opting in requires the `ciphertext` library and
         # `REBOOT_CRYPTO_ROOT_KEYS`.
         store_tokens: bool = False,
+        # The identity claims to deliver on every sign-in; see
+        # `OAuthProvider.__init__`. The scopes these claims need are
+        # requested automatically (see `_requested_scopes`).
+        claims: Optional[Sequence[str] | Mapping[str, str]] = None,
     ):
 
-        super().__init__()
+        super().__init__(claims=claims)
         self._client_id = client_id
         self._client_secret = client_secret
         self._extra_scopes = scopes or []
@@ -212,10 +344,15 @@ class RegisteredOAuthProvider(OAuthProvider):
         return self._store_tokens
 
     def _requested_scopes(self) -> list[str]:
-        """The full scope list: the required base scope plus the
-        developer's extras (deduplicated, base scope first).
+        """The full scope list: the required base scope, the scopes
+        the requested identity claims need (see `_AVAILABLE_CLAIMS`),
+        plus the developer's extras (deduplicated, base scope first).
         """
         scopes = [self._REQUIRED_SCOPE]
+        for name in (self._claims or {}):
+            scope = self._AVAILABLE_CLAIMS[name]
+            if scope is not None and scope not in scopes:
+                scopes.append(scope)
         for scope in self._extra_scopes:
             if scope not in scopes:
                 scopes.append(scope)
@@ -242,7 +379,9 @@ class Google(RegisteredOAuthProvider):
     """
     Google OAuth provider (OpenID Connect).
 
-    Obtains the user ID from the OIDC ID token's `sub` claim.
+    Obtains the user ID from the OIDC ID token's `sub` claim. Pass
+    `claims=` to deliver the user's identity claims; the scopes they
+    need (`email`, `profile`) are requested automatically.
     """
 
     _AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
@@ -251,6 +390,24 @@ class Google(RegisteredOAuthProvider):
     # `openid` is the minimum OIDC scope; gives us an ID token with the
     # `sub` claim (the user's ID).
     _REQUIRED_SCOPE = "openid"
+
+    # The standard OIDC identity claims Google can put in its ID
+    # token, each mapped to the scope that makes it appear: `email`
+    # claims need the `email` scope, the rest the `profile` scope.
+    # Absent claims are simply omitted (see `_presented_claims`), so
+    # the full menu is safe to list even when not all are returned.
+    # See
+    # https://developers.google.com/identity/openid-connect/openid-connect.
+    _AVAILABLE_CLAIMS = {
+        "email": "email",
+        "email_verified": "email",
+        "name": "profile",
+        "given_name": "profile",
+        "family_name": "profile",
+        "picture": "profile",
+        "locale": "profile",
+        "profile": "profile",
+    }
 
     @property
     def token_service_id(self) -> str:
@@ -333,6 +490,10 @@ class Google(RegisteredOAuthProvider):
         return ExchangeResult(
             user_id=UserId(user_id),
             tokens=self._tokens_from_response(token_response),
+            # The ID token carries the requested identity claims (we
+            # requested the scopes they need); surface whichever are
+            # present, under their presented names.
+            claims=self._presented_claims(decoded),
         )
 
     def _tokens_from_response(
@@ -365,6 +526,14 @@ class GitHub(RegisteredOAuthProvider):
     """
     GitHub OAuth provider (plain OAuth 2.0).
 
+    Pass `claims=` to deliver the user's verified email (`email` /
+    `email_verified`); the `user:email` scope it needs is requested
+    automatically. GitHub issues no OIDC ID token, so the claims come
+    from `GET /user/emails`: the user's primary address, only when
+    GitHub has verified it (no email claims otherwise) — never the
+    `GET /user` `email` field, which is the user-chosen *public
+    profile* email and may be unverified.
+
     Note on refresh tokens (relevant only with `store_tokens=True`):
     whether GitHub issues a `refresh_token` is entirely a property of how
     the credentials were created, not anything we can request:
@@ -386,10 +555,23 @@ class GitHub(RegisteredOAuthProvider):
     _AUTHORIZATION_ENDPOINT = "https://github.com/login/oauth/authorize"
     _TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token"
     _USER_API = "https://api.github.com/user"
+    _USER_EMAILS_API = "https://api.github.com/user/emails"
 
     # `read:user`: minimum scope needed to call `GET /user` and obtain
     # the numeric user ID.
     _REQUIRED_SCOPE = "read:user"
+
+    # The identity claims GitHub can deliver, each mapped to the
+    # scope that authorizes reading them. GitHub is not an OIDC
+    # provider, so these come from its REST API (see
+    # `_email_claims_source`), not an ID token. The menu stays
+    # limited to the verified email claims until we have a good way
+    # to test the GitHub integration end to end. See
+    # https://docs.github.com/en/rest/users/emails.
+    _AVAILABLE_CLAIMS = {
+        "email": "user:email",
+        "email_verified": "user:email",
+    }
 
     @property
     def token_service_id(self) -> str:
@@ -456,13 +638,58 @@ class GitHub(RegisteredOAuthProvider):
                 response.raise_for_status()
                 user_info = await response.json()
 
+            # Resolve the requested identity claims; when none were
+            # requested this extra API round trip is skipped
+            # entirely.
+            claims: Optional[dict[str, Any]] = None
+            if self._claims is not None:
+                claims = self._presented_claims(
+                    await self._email_claims_source(session, access_token)
+                )
+
         user_id = user_info.get("id")
         if user_id is None:
             raise ValueError("GitHub user API did not return an 'id' field.")
         return ExchangeResult(
             user_id=UserId(str(user_id)),
             tokens=self._tokens_from_response(token_response),
+            claims=claims,
         )
+
+    async def _email_claims_source(
+        self,
+        session: aiohttp.ClientSession,
+        access_token: str,
+    ) -> dict[str, Any]:
+        """The source claims for the email identity claims: the
+        user's primary email address from `GET /user/emails` (which
+        the `user:email` scope derived from the requested claims
+        allows), only when GitHub has verified it. A user whose
+        primary address is unverified gets no email claims at all —
+        an unverified address must not become a verified identity
+        claim.
+        """
+        async with session.get(
+            self._USER_EMAILS_API,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "application/json",
+            },
+        ) as response:
+            response.raise_for_status()
+            email_response = await response.json()
+        for entry in (
+            email_response if isinstance(email_response, list) else []
+        ):
+            if not isinstance(entry, dict) or not entry.get("primary"):
+                continue
+            if entry.get("verified"):
+                return {
+                    "email": entry.get("email"),
+                    "email_verified": True,
+                }
+            break
+        return {}
 
     def _tokens_from_response(
         self,
@@ -510,13 +737,33 @@ class Auth0(RegisteredOAuthProvider):
 
     Obtains the user ID from the OIDC ID token's `sub` claim (shaped
     like `<connection>|<id>`, e.g. `google-oauth2|108…`), falling back
-    to the `/userinfo` endpoint if no ID token is returned.
+    to the `/userinfo` endpoint if no ID token is returned. Pass
+    `claims=` to deliver the user's identity claims; the scopes they
+    need (`email`, `profile`) are requested automatically.
     """
 
     # `openid` is the minimum OIDC scope; yields an ID token with the
-    # `sub` claim (the user's Auth0 ID). Add `profile`/`email` via
-    # `scopes=` if the app needs them.
+    # `sub` claim (the user's Auth0 ID).
     _REQUIRED_SCOPE = "openid"
+
+    # The standard OIDC identity claims Auth0 can put in its ID
+    # token, each mapped to the scope that makes it appear: `email`
+    # claims need the `email` scope, the rest the `profile` scope.
+    # Which are populated depends on the upstream connection, so
+    # absent claims are simply omitted (see `_presented_claims`).
+    # See
+    # https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes.
+    _AVAILABLE_CLAIMS = {
+        "email": "email",
+        "email_verified": "email",
+        "name": "profile",
+        "given_name": "profile",
+        "family_name": "profile",
+        "middle_name": "profile",
+        "nickname": "profile",
+        "picture": "profile",
+        "updated_at": "profile",
+    }
 
     # Auth0 grants a refresh token only when `offline_access` is
     # requested (the analogue of Google's `access_type=offline`); see
@@ -533,12 +780,14 @@ class Auth0(RegisteredOAuthProvider):
         client_secret: Optional[str],
         scopes: Optional[list[str]] = None,
         store_tokens: bool = False,
+        claims: Optional[Sequence[str] | Mapping[str, str]] = None,
     ):
         super().__init__(
             client_id=client_id,
             client_secret=client_secret,
             scopes=scopes,
             store_tokens=store_tokens,
+            claims=claims,
         )
         self._domain = self._normalize_domain(domain)
 
@@ -559,9 +808,11 @@ class Auth0(RegisteredOAuthProvider):
         return host.strip("/")
 
     @staticmethod
-    def _sub_from_id_token(id_token: Optional[str]) -> Optional[str]:
-        """Decode an OIDC ID token and return its `sub` claim, or `None`
-        if there's no token or no `sub`.
+    def _decoded_id_token(
+        id_token: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        """Decode an OIDC ID token's claims, or `None` if there's no
+        token.
 
         Decodes without verifying the signature: we received this token
         directly from the provider's token endpoint over TLS, so the
@@ -571,8 +822,7 @@ class Auth0(RegisteredOAuthProvider):
         """
         if not id_token:
             return None
-        decoded = jwt.decode(id_token, options={"verify_signature": False})
-        return decoded.get("sub")
+        return jwt.decode(id_token, options={"verify_signature": False})
 
     @property
     def _authorization_endpoint(self) -> str:
@@ -647,7 +897,12 @@ class Auth0(RegisteredOAuthProvider):
                 response.raise_for_status()
                 token_response = await response.json()
 
-            user_id = self._sub_from_id_token(token_response.get("id_token"))
+            decoded = self._decoded_id_token(token_response.get("id_token"))
+            user_id = decoded.get("sub") if decoded is not None else None
+            # The ID token carries the requested identity claims (we
+            # requested the scopes they need); surface whichever are
+            # present, under their presented names.
+            claims = self._presented_claims(decoded or {})
             if user_id is None:
                 # No ID token (shouldn't happen with the `openid`
                 # scope, but be defensive): fall back to `/userinfo`,
@@ -666,6 +921,10 @@ class Auth0(RegisteredOAuthProvider):
                     response.raise_for_status()
                     user_info = await response.json()
                 user_id = user_info.get("sub")
+                # `/userinfo` responses use the same standard claim
+                # names as the ID token, and the TLS round-trip to
+                # Auth0 makes them a verified source too.
+                claims = self._presented_claims(user_info)
 
         if user_id is None:
             raise ValueError(
@@ -675,6 +934,7 @@ class Auth0(RegisteredOAuthProvider):
         return ExchangeResult(
             user_id=UserId(user_id),
             tokens=self._tokens_from_response(token_response),
+            claims=claims,
         )
 
     def _tokens_from_response(
@@ -752,7 +1012,8 @@ class Anonymous(OAuthProvider):
         # ULID rather than UUIDv7: same entropy, but the Crockford
         # base32 encoding is shorter and easier on the human eye —
         # relevant here because anonymous user IDs are likely to be seen
-        # by humans.
+        # by humans. No identity claims: an anonymous user has no
+        # verified identity to draw them from.
         return ExchangeResult(user_id=UserId(f"anon-{ULID()}"), tokens=None)
 
 
@@ -807,12 +1068,26 @@ class Development(OAuthProvider):
     For local development only; do not use in production.
     """
 
+    # The identity claims `Development` fabricates for its fake
+    # identities, so claims-consuming application code can be
+    # exercised locally. No scopes: there is no identity provider to
+    # request anything from.
+    _AVAILABLE_CLAIMS = {
+        "email": None,
+        "email_verified": None,
+        "name": None,
+    }
+
     def __init__(
         self,
         *,
         access_token_ttl_seconds: int = _DEFAULT_ACCESS_TOKEN_TTL_SECONDS,
+        claims: Optional[Sequence[str] | Mapping[str, str]] = None,
     ):
-        super().__init__(access_token_ttl_seconds=access_token_ttl_seconds)
+        super().__init__(
+            access_token_ttl_seconds=access_token_ttl_seconds,
+            claims=claims,
+        )
         self._login_page_template: Optional[Template] = None
 
     def mount_routes(self, http: PythonWebFramework.HTTP) -> None:
@@ -949,6 +1224,17 @@ class Development(OAuthProvider):
         return ExchangeResult(
             user_id=UserId(f"dev-{digest[:16]}"),
             tokens=None,
+            # Fabricate the source claims a real provider would
+            # deliver, matching the identity shown on the login page,
+            # and present the requested ones, so that claims-consuming
+            # application code can be exercised in local development.
+            claims=self._presented_claims(
+                {
+                    "email": f"{code.lower()}@example.com",
+                    "email_verified": True,
+                    "name": code,
+                }
+            ),
         )
 
 

--- a/reboot/aio/auth/oauth_server.py
+++ b/reboot/aio/auth/oauth_server.py
@@ -319,11 +319,11 @@ class OAuthServer:
         # The application's human-readable title, e.g. "Hipster Chat".
         application_title: str,
         auto_construct_state_type_full_names: Optional[Sequence[str]] = None,
-        post_authenticate: Optional[Callable[[ExternalContext, str],
-                                             Awaitable[None]]] = None,
+        authenticated: Optional[Callable[[ExternalContext, str],
+                                         Awaitable[None]]] = None,
         allowed_origins: Optional[Sequence[str]] = None,
     ):
-        """`post_authenticate`, if given, runs right after each fresh
+        """`authenticated`, if given, runs right after each fresh
         access token is minted for a user, receiving an app-internal
         `ExternalContext` and the `user_id` the token was minted for.
         It must be idempotent and inexpensive — it can run on every
@@ -341,7 +341,7 @@ class OAuthServer:
         self._auto_construct_state_type_full_names: list[str] = list(
             auto_construct_state_type_full_names or []
         )
-        self._post_authenticate = post_authenticate
+        self._authenticated = authenticated
         self._access_token_ttl_seconds = provider.access_token_ttl_seconds
         # Derived from the Reboot-managed cryptographic root keys; raises
         # if `REBOOT_CRYPTO_ROOT_KEYS` is unset/malformed (fail fast at
@@ -439,13 +439,13 @@ class OAuthServer:
         Every JWT this server hands out is minted here: using a Reboot
         app always requires the user to authenticate, and this is the
         one place that mints the token proving it. After minting,
-        `post_authenticate` (if set) is fired with `context`; given the
-        idempotent `post_authenticate` its contract requires, this
+        `authenticated` (if set) is fired with `context`; given the
+        idempotent `authenticated` its contract requires, this
         method is in turn safe to call repeatedly for the same user.
 
         `context` is an app-internal `ExternalContext`: the routes that
         mint are `app_internal=True`, so the auto-construct Writer that
-        `post_authenticate` runs is trusted app code rather than a call
+        `authenticated` runs is trusted app code rather than a call
         made as the (not-yet-existent) user.
         """
         access_token = self._make_jwt(
@@ -465,13 +465,13 @@ class OAuthServer:
             },
             ttl_seconds=_REFRESH_TOKEN_TTL_SECONDS,
         )
-        # Fire the post-authenticate hook before returning the tokens,
+        # Fire the authenticated hook before returning the tokens,
         # so a failure surfaces as a 500 with no token body /
         # `Set-Cookie` rather than handing back a token whose
-        # post-authenticate side effects never ran. If the hook raises
+        # authenticated side effects never ran. If the hook raises
         # we propagate it.
-        if self._post_authenticate is not None:
-            await self._post_authenticate(context, user_id)
+        if self._authenticated is not None:
+            await self._authenticated(context, user_id)
         return {
             "access_token": access_token,
             "token_type": "bearer",

--- a/reboot/aio/auth/oauth_server.py
+++ b/reboot/aio/auth/oauth_server.py
@@ -43,7 +43,7 @@ from starlette.responses import (
     RedirectResponse,
     Response,
 )
-from typing import Any, Awaitable, Callable, Optional, Sequence
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence
 from urllib.parse import urlencode, urlparse
 
 logger = logging.getLogger(__name__)
@@ -319,15 +319,20 @@ class OAuthServer:
         # The application's human-readable title, e.g. "Hipster Chat".
         application_title: str,
         auto_construct_state_type_full_names: Optional[Sequence[str]] = None,
-        authenticated: Optional[Callable[[ExternalContext, str],
-                                         Awaitable[None]]] = None,
+        authenticated: Optional[
+            Callable[[ExternalContext, str, Optional[Mapping[str, Any]]],
+                     Awaitable[None]]] = None,
         allowed_origins: Optional[Sequence[str]] = None,
     ):
         """`authenticated`, if given, runs right after each fresh
         access token is minted for a user, receiving an app-internal
-        `ExternalContext` and the `user_id` the token was minted for.
-        It must be idempotent and inexpensive — it can run on every
-        mint for the same user.
+        `ExternalContext`, the `user_id` the token was minted for, and
+        the user's verified identity claims when they are freshly
+        available (only at an identity provider code exchange, and
+        only when the provider was constructed to deliver claims via
+        `claims=`; `None` on refreshes and other mints that don't
+        consult the provider). It must be idempotent and inexpensive —
+        it can run on every mint for the same user.
 
         `allowed_origins` is `Application(allowed_origins=...)`'s
         explicit allow-list (with `None` meaning it, like `oauth=`,
@@ -431,6 +436,7 @@ class OAuthServer:
         client_id: str,
         base: str,
         context: ExternalContext,
+        claims: Optional[Mapping[str, Any]] = None,
     ) -> dict[str, Any]:
         """Mint a fresh access/refresh token pair for `user_id` and
         return the standard OAuth token response body (`access_token`,
@@ -439,9 +445,17 @@ class OAuthServer:
         Every JWT this server hands out is minted here: using a Reboot
         app always requires the user to authenticate, and this is the
         one place that mints the token proving it. After minting,
-        `authenticated` (if set) is fired with `context`; given the
-        idempotent `authenticated` its contract requires, this
-        method is in turn safe to call repeatedly for the same user.
+        `authenticated` (if set) is fired with `context` and `claims`;
+        given the idempotent `authenticated` its contract requires,
+        this method is in turn safe to call repeatedly for the same
+        user.
+
+        `claims` are the user's verified identity claims, passed only
+        by the identity provider code exchange (the one moment they
+        are freshly available), and only when the provider was
+        constructed to deliver claims (`claims=`); every other mint
+        leaves them `None`, which delivers no claims but still
+        ensures the user's state exists.
 
         `context` is an app-internal `ExternalContext`: the routes that
         mint are `app_internal=True`, so the auto-construct Writer that
@@ -471,7 +485,7 @@ class OAuthServer:
         # authenticated side effects never ran. If the hook raises
         # we propagate it.
         if self._authenticated is not None:
-            await self._authenticated(context, user_id)
+            await self._authenticated(context, user_id, claims)
         return {
             "access_token": access_token,
             "token_type": "bearer",
@@ -1291,11 +1305,22 @@ class OAuthServer:
         # flows that don't go through a browser these cookies are
         # set but ignored (the MCP client doesn't process
         # `Set-Cookie`).
+        #
+        # The identity provider code exchange just above is the one
+        # moment the user's verified claims are fresh, so this is the
+        # mint that delivers them; refresh grants and session-cookie
+        # SSO never reach here and so deliver no claims. `None` means
+        # claim delivery is off — the provider was constructed
+        # without `claims=` or has no verified claims source (e.g.
+        # `Anonymous`) — and delivers nothing; an empty mapping is
+        # the provider's complete, current claim set, and clears any
+        # previously delivered claims.
         tokens = await self._mint_tokens_for_user(
             user_id=user_id,
             client_id=str(pending["client_id"]),
             base=origin_from_request(request),
             context=external_context(request),
+            claims=result.claims,
         )
         self._set_session_cookies(
             response,

--- a/reboot/aio/servicers.py
+++ b/reboot/aio/servicers.py
@@ -11,7 +11,7 @@ from mcp.server.fastmcp import FastMCP
 from rbt.v1alpha1.application_config_pb2 import ApplicationConfig
 from reboot.aio.external import ExternalContext
 from reboot.aio.types import ServiceName, StateTypeName
-from typing import Callable, Optional
+from typing import Any, Callable, Mapping, Optional
 
 
 class Servicer(ABC):
@@ -59,9 +59,23 @@ class Servicer(ABC):
     # Naming: has a leading underscore to ensure it doesn't collide with
     # customer-API-defined methods; those can't use leading underscores.
     @staticmethod
-    async def _auto_construct(context: ExternalContext, state_id: str) -> None:
+    async def _authenticated(
+        context: ExternalContext,
+        state_id: str,
+        claims: Optional[Mapping[str, Any]] = None,
+    ) -> None:
         """
-        Auto-construct a state with the given ID, if auto-constructable.
+        Record that a user authenticated: construct their state with
+        the given ID if it does not exist yet (idempotently, so
+        repeated calls are a NOOP), then, when `claims` is given,
+        deliver the user's verified identity claims through the
+        state's `set_claims` method.
+
+        `claims=None` means the caller has no claims information for
+        this authentication (e.g. a token refresh, which never
+        consults the identity provider) and so skips `set_claims`
+        entirely; it never means "the user has no claims" and never
+        clears previously delivered claims.
 
         Overridden by generated code for auto-constructable state types.
         """

--- a/reboot/aio/tests.py
+++ b/reboot/aio/tests.py
@@ -25,7 +25,15 @@ from reboot.settings import (
     ENVVAR_REBOOT_ENABLE_EVENT_LOOP_BLOCKED_WATCHDOG,
     ENVVAR_REBOOT_IN_TEST,
 )
-from typing import Any, Awaitable, Callable, Optional, Sequence, overload
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Mapping,
+    Optional,
+    Sequence,
+    overload,
+)
 from unittest import mock
 
 
@@ -157,6 +165,7 @@ class Reboot(reboot.aio.reboot.Reboot):
     async def make_valid_oauth_access_token(
         self,
         user_id: str = "test-user",
+        claims: Optional[Mapping[str, Any]] = None,
     ) -> str:
         """
         Mint a valid JWT OAuth access token for use in tests.
@@ -170,7 +179,9 @@ class Reboot(reboot.aio.reboot.Reboot):
         just does `await rbt.make_valid_oauth_access_token(...)`
         and immediately opens an MCP session finds the `User`
         actor already materialized, matching the behaviour MCP-via-
-        OAuth flows get for free.
+        OAuth flows get for free. Pass `claims` to also deliver a
+        user's verified identity claims, exactly as a real sign-in
+        code exchange does — exercising a servicer's `set_claims`.
 
         The identity is just whatever the developer specified — no
         actual authentication takes place.
@@ -204,14 +215,17 @@ class Reboot(reboot.aio.reboot.Reboot):
             # token has a recognisable shape if dumped in a debug
             # log.
             base="http://reboot-test",
-            # Production mints from `app_internal=True` routes, so
-            # `_post_authenticate`'s auto-construct Writer runs as
-            # trusted app code; tests have no request, so build an
-            # app-internal context off the test `Reboot` directly.
+            # Production mints from `app_internal=True` routes, so the
+            # `authenticated` hook's auto-construct/`set_claims` calls
+            # run as trusted app code; tests have no request, so build
+            # an app-internal context off the test `Reboot` directly.
             context=self.create_external_context(
                 name="reboot.tests.make_valid_oauth_access_token",
                 app_internal=True,
             ),
+            # Delivered the way a real sign-in code exchange delivers
+            # them, folded into the mint chokepoint.
+            claims=claims,
         )
         return tokens["access_token"]
 

--- a/reboot/api.py
+++ b/reboot/api.py
@@ -8,7 +8,11 @@ from google.protobuf import json_format
 from google.protobuf.message import Message
 from google.protobuf.struct_pb2 import Value
 from pydantic.fields import FieldInfo
-from reboot.settings import AUTO_CONSTRUCT_METHOD, AUTO_CONSTRUCT_STATE_TYPE
+from reboot.settings import (
+    AUTO_CONSTRUCT_METHOD,
+    AUTO_CONSTRUCT_STATE_TYPE,
+    SET_CLAIMS_METHOD,
+)
 from typing import (
     Any,
     Dict,
@@ -1173,6 +1177,20 @@ class Type(pydantic.BaseModel):
         )
 
 
+class SetClaimsRequest(Model):
+    """Request for the `set_claims` method the framework injects on
+    auto-constructed state types. The framework fills it in when it
+    delivers a user's verified identity claims at sign-in; it is not
+    meant to be built by application code.
+    """
+    # The user's verified identity claims, keyed by their presented
+    # names. A `dict[str, Any]` (a `map<string, google.protobuf.Value>`
+    # on the wire) so it carries free-form JSON claim values verbatim
+    # and stays decoupled from whatever claims the identity provider
+    # was configured to deliver.
+    claims: dict[str, Any] = Field(tag=1, default_factory=dict)
+
+
 class API(pydantic.BaseModel):
     """Main API definition containing multiple Reboot data types.
     We set extra='allow' to permit dynamic data type fields, i.e.
@@ -1255,6 +1273,20 @@ class API(pydantic.BaseModel):
                         f"'{type_name}' for a new AI "
                         "session."
                     )
+                if SET_CLAIMS_METHOD in data_type.methods:
+                    raise UserPydanticError(
+                        f"'{SET_CLAIMS_METHOD}' is a "
+                        "reserved method name for "
+                        f"{type_name} types: the framework "
+                        "calls it to deliver a user's "
+                        "verified identity claims. If you "
+                        "want to act on those claims, "
+                        f"override the default "
+                        f"'{SET_CLAIMS_METHOD}' Transaction "
+                        "in your servicer implementation "
+                        "instead of declaring it in the API "
+                        "definition."
+                    )
                 # The auto-constructed `create` is a `Transaction`, so
                 # that a servicer overriding it can call other state
                 # machines while constructing a `User`, e.g. "when a
@@ -1268,6 +1300,20 @@ class API(pydantic.BaseModel):
                     # is called by the Reboot internally and shouldn't
                     # be exposed as an MCP tool so others can't call it
                     # directly.
+                    mcp=None,
+                )
+                # The `set_claims` method delivers the user's verified
+                # identity claims. It is a `Transaction` (like
+                # `create`) so a servicer overriding it can call other
+                # state machines. It is a plain method, not a
+                # constructor: the framework calls it only after
+                # `create` has brought the state into existence.
+                data_type.methods[SET_CLAIMS_METHOD] = Transaction(
+                    request=SetClaimsRequest,
+                    response=None,
+                    factory=False,
+                    # `set_claims` is only called app-internal, so never
+                    # over MCP.
                     mcp=None,
                 )
 

--- a/reboot/api.py
+++ b/reboot/api.py
@@ -4,7 +4,9 @@ import re
 import types
 import typing
 from enum import Enum
+from google.protobuf import json_format
 from google.protobuf.message import Message
+from google.protobuf.struct_pb2 import Value
 from pydantic.fields import FieldInfo
 from reboot.settings import AUTO_CONSTRUCT_METHOD, AUTO_CONSTRUCT_STATE_TYPE
 from typing import (
@@ -302,6 +304,13 @@ def _pydantic_to_proto(
         # or a 'Model'. Otherwise it will be a collection
         # type like 'list' or 'dict'.
         input_type_or_origin = input_type
+
+    if input_type is Any:
+        # An `Any`-typed value — e.g. a `dict[str, Any]` map value —
+        # is carried on the wire as a `google.protobuf.Value`, which
+        # represents any JSON value: `null`, a number, a string, a
+        # bool, a list, or an object.
+        return json_format.ParseDict(input, Value())
 
     if input_type_or_origin is Union or input_type_or_origin is types.UnionType:
         # It might be a discriminated union or an `Optional[T]`.
@@ -624,6 +633,12 @@ def _proto_to_pydantic(
         # we don't want to create an arbitrary data structure, but return
         # 'None' directly.
         return None
+
+    if output_type is Any:
+        # Reverse of the `Any` case in `_pydantic_to_proto`: a
+        # `google.protobuf.Value` becomes the JSON value it holds.
+        assert isinstance(input, Value)
+        return json_format.MessageToDict(input)
 
     output_type_or_origin = get_origin(output_type)
 
@@ -1081,6 +1096,11 @@ class Type(pydantic.BaseModel):
                             f"non-string value `{arg}`. Only string "
                             "literals are supported."
                         )
+            elif field_type is Any:
+                # `dict[str, Any]` becomes a Protobuf `map<string,
+                # google.protobuf.Value>` carrying arbitrary JSON
+                # values; the value type needs no further validation.
+                pass
             elif issubclass(field_type, pydantic.BaseModel):
                 if not issubclass(field_type, Model):
                     state_or_method = ""

--- a/reboot/examples/agent-wiki/backend/tests/wiki_test.py
+++ b/reboot/examples/agent-wiki/backend/tests/wiki_test.py
@@ -96,10 +96,10 @@ class _WikiTestBase(unittest.IsolatedAsyncioTestCase):
             user_id=self.user_id,
         )
         # `User` is an auto-constructed state type: in
-        # production the MCP session's "new session" hook
-        # calls `_auto_construct` for the authenticated user.
-        # Tests don't go through that hook, so we do it here.
-        await UserServicer._auto_construct(
+        # production the framework calls `_authenticated` for the
+        # authenticated user when their token is minted. Tests can
+        # trigger it explicitly here.
+        await UserServicer._authenticated(
             self.context,
             state_id=self.user_id,
         )

--- a/reboot/examples/chick-potle/backend/tests/food_test.py
+++ b/reboot/examples/chick-potle/backend/tests/food_test.py
@@ -37,10 +37,10 @@ class ServicerTest(unittest.IsolatedAsyncioTestCase):
             user_id=self.user_id,
         )
         # `User` is an auto-constructed state type: in
-        # production the MCP session's "new session" hook
-        # calls `_auto_construct` for the authenticated user.
-        # Tests don't go through that hook, so we do it here.
-        await UserServicer._auto_construct(
+        # production the framework calls `_authenticated` for the
+        # authenticated user when their token is minted. Tests can
+        # trigger it explicitly here.
+        await UserServicer._authenticated(
             self.context,
             state_id=self.user_id,
         )

--- a/reboot/examples/reboot-swag-store/backend/tests/store_servicer_test.py
+++ b/reboot/examples/reboot-swag-store/backend/tests/store_servicer_test.py
@@ -101,7 +101,7 @@ class TestStoreServicers(unittest.IsolatedAsyncioTestCase):
             name=f"test-{self.id()}",
             user_id=self.user_id,
         )
-        await UserServicer._auto_construct(
+        await UserServicer._authenticated(
             self.context,
             state_id=self.user_id,
         )

--- a/reboot/ping/ping.py
+++ b/reboot/ping/ping.py
@@ -150,6 +150,17 @@ class PongServicer(Pong.Servicer):
 
 class UserServicer(User.Servicer):
 
+    async def set_claims(
+        self,
+        context: TransactionContext,
+        request: User.SetClaimsRequest,
+    ) -> None:
+        """Transcribe the delivered identity claims into state. A full
+        replace: the request carries the complete, current claims on
+        every sign-in, so re-deriving `email` each time keeps it
+        fresh (and converges when it changes)."""
+        self.state.email = request.claims.get("email", "")
+
     async def create_counter(
         self,
         context: TransactionContext,
@@ -182,7 +193,7 @@ class UserServicer(User.Servicer):
 
     async def whoami(self, context: ReaderContext) -> WhoAmIResponse:
         user_id = context.auth.user_id if context.auth else "unauthenticated"
-        return WhoAmIResponse(user_id=user_id)
+        return WhoAmIResponse(user_id=user_id, email=self.state.email)
 
 
 class CounterServicer(Counter.Servicer):
@@ -274,6 +285,9 @@ async def main():
         # TODO: investigate why MCP inspectors don't refresh this
         # token.
         access_token_ttl_seconds=3600,
+        # The `email` identity claim, which `UserServicer.set_claims`
+        # transcribes into `User` state.
+        claims=["email"],
     )
 
     application = Application(

--- a/reboot/ping/ping_api.py
+++ b/reboot/ping/ping_api.py
@@ -74,10 +74,14 @@ class ListCountersResponse(Model):
 
 class WhoAmIResponse(Model):
     user_id: str = Field(tag=1)
+    email: str = Field(tag=2, default="")
 
 
 class UserState(Model):
     counter_ids: list[str] = Field(tag=1, default_factory=list)
+    # The email identity claim most recently delivered at sign-in
+    # (empty when the identity provider supplied none).
+    email: str = Field(tag=2, default="")
 
 
 # -- Counter models (simple counter). --

--- a/reboot/plugin/skills/chat-app/references/auth-oauth-providers.md
+++ b/reboot/plugin/skills/chat-app/references/auth-oauth-providers.md
@@ -48,6 +48,35 @@ the upstream connection (`google-oauth2|…`, `auth0|…`, `github|…`), the
 namespace-permanence rule below still applies: changing which Auth0
 connections you offer can change users' `sub`s.
 
+**Identity claims.** Signing in identifies the user; pass `claims=`
+at provider construction to also learn _about_ them: e.g.
+`Google(claims=["email"])` delivers the user's verified email to
+your `User` type's `set_claims` method on every sign-in. Each
+provider rejects — at construction, naming the claims it has
+available — any claim it cannot deliver, and automatically requests
+whatever OAuth scopes the requested claims need. A claim can be
+presented to the application under a different name via a mapping
+(`claims={"email": "verified-email"}`). Without `claims=` no claims
+are delivered and `set_claims` is never called. To act on the
+delivered claims, override `set_claims` in the `User.Servicer`
+(the generated default is a no-op):
+
+```python
+class UserServicer(User.Servicer):
+    async def set_claims(
+        self,
+        context: TransactionContext,
+        request: User.SetClaimsRequest,
+    ) -> None:
+        self.state.email = request.claims.get("email", "")
+```
+
+`request.claims` is the complete, current set of verified claims
+(a `dict[str, Any]`), so treat `set_claims` as a full replace:
+it runs on every sign-in, and re-delivering the same claims must be
+harmless — and a claim absent from the request is one the provider
+no longer asserts, so overwrite rather than merge.
+
 **Need user management, not just a user id?** `Google` / `GitHub` give
 you exactly one thing: a stable `context.auth.user_id`. If the app needs
 more — user profiles, email/password accounts, password resets, email

--- a/reboot/plugin/skills/python/references/testing-harness.md
+++ b/reboot/plugin/skills/python/references/testing-harness.md
@@ -222,6 +222,17 @@ await UserServicer._authenticated(
 Symptom if you forget: the first call into `User.ref(self.user_id)`
 aborts because the state was never constructed.
 
+To exercise a servicer's `set_claims`, deliver identity claims the
+way a real sign-in does — pass `claims=` to
+`make_valid_oauth_access_token` (or to `_authenticated` directly):
+
+```python
+token = await self.rbt.make_valid_oauth_access_token(
+    user_id=self.user_id,
+    claims={"email": "alice@example.com"},
+)
+```
+
 ## Last Resort: Permissive Authorizers
 
 It is possible to subclass a servicer and override `authorizer()` to

--- a/reboot/plugin/skills/python/references/testing-harness.md
+++ b/reboot/plugin/skills/python/references/testing-harness.md
@@ -204,14 +204,17 @@ be attributed to a user.
 ## Auto-Construct Under Auth
 
 If a state type has a real authorizer that gates its constructor —
-typically the case for `User`-shaped front-door types — the MCP session
-hook in production calls `_auto_construct` to create the state for an
-authenticated user. Tests that don't use MCP skip that hook, so trigger
-it manually right after creating the context:
+typically the case for `User`-shaped front-door types — the framework
+calls `_authenticated` to create the state for an authenticated user
+whenever a token is minted for them. `create_external_context_as(...)`
+and `make_valid_oauth_access_token(...)` mint a token, so they
+construct the `User` as a side effect and most tests need no manual
+setup. To construct the state for a user no context was created for,
+call `_authenticated` directly with an app-internal context:
 
 ```python
-await UserServicer._auto_construct(
-    self.context,
+await UserServicer._authenticated(
+    self.rbt.create_external_context(name="internal", app_internal=True),
     state_id=self.user_id,
 )
 ```

--- a/reboot/plugin/skills/upgrade/migrations/next/rename-auto-construct-authenticated.md
+++ b/reboot/plugin/skills/upgrade/migrations/next/rename-auto-construct-authenticated.md
@@ -1,0 +1,17 @@
+## `_auto_construct` was renamed to `_authenticated`
+
+The generated static method
+`<StateType>._auto_construct(context, state_id)` on auto-construct
+state types (and on their servicers) is now
+`<StateType>._authenticated(context, state_id, claims=None)`. It
+still constructs the state idempotently; the new optional `claims`
+parameter is delivered by the framework and is not something callers
+need to pass.
+
+If any file calls `._auto_construct(`, rename the call to
+`._authenticated(`. Arguments are unchanged.
+
+If any servicer class defines its own `_auto_construct` method,
+rename the definition to `_authenticated` and add a trailing optional
+`claims: Mapping[str, Any] | None = None` parameter, or the framework
+will no longer invoke it.

--- a/reboot/plugin/skills/web-app/SKILL.md
+++ b/reboot/plugin/skills/web-app/SKILL.md
@@ -111,7 +111,8 @@ Recommended sequence:
    load the
    [chat-app/references/auth-oauth-providers.md](../chat-app/references/auth-oauth-providers.md)
    reference for the per-provider details (client IDs, scopes,
-   `store_tokens=True`, the user-ID-namespace gotcha when
+   `store_tokens=True`, requesting identity claims like the
+   user's email via `claims=`, the user-ID-namespace gotcha when
    switching providers post-launch). In unit tests, keep
    `token_verifier=<your IdP verifier>` exactly as in production —
    the test harness's OAuth server verifies the impersonation token

--- a/reboot/protoc_gen_reboot_generic.py
+++ b/reboot/protoc_gen_reboot_generic.py
@@ -32,7 +32,10 @@ from reboot.options import (
     has_service_options,
     is_reboot_state,
 )
-from reboot.settings import AUTO_CONSTRUCT_PROTO_METHOD
+from reboot.settings import (
+    AUTO_CONSTRUCT_PROTO_METHOD,
+    SET_CLAIMS_PROTO_METHOD,
+)
 from reboot.version import REBOOT_VERSION
 from typing import Any, Literal, Optional, Sequence
 
@@ -954,15 +957,16 @@ class RebootProtocPlugin(ProtocPlugin):
             # Note: duplicate methods between services are checked for during
             #       client generation.
 
-        # Validate that auto-constructed states have the
-        # auto-constructor.
+        # Validate that auto-constructed states have both the
+        # auto-constructor and the claims-delivery method the
+        # framework calls.
         if proto_state.auto_construct != options_pb2.AUTO_CONSTRUCT_UNSPECIFIED:
-            has_auto_construct = any(
-                method.proto.name == AUTO_CONSTRUCT_PROTO_METHOD
+            method_names = {
+                method.proto.name
                 for service in base_services
                 for method in service.methods
-            )
-            if not has_auto_construct:
+            }
+            if AUTO_CONSTRUCT_PROTO_METHOD not in method_names:
                 raise UserProtoError(
                     f"State type '{proto_state.name}' requires "
                     f"a '{AUTO_CONSTRUCT_PROTO_METHOD}' "
@@ -973,6 +977,24 @@ class RebootProtocPlugin(ProtocPlugin):
                     "    option (rbt.v1alpha1.method) = "
                     "{ transaction: {} };\n"
                     "  }"
+                )
+            if SET_CLAIMS_PROTO_METHOD not in method_names:
+                raise UserProtoError(
+                    f"State type '{proto_state.name}' requires "
+                    f"a '{SET_CLAIMS_PROTO_METHOD}' Transaction "
+                    "method through which the framework delivers "
+                    "each user's verified identity claims. Add to "
+                    "your service:\n"
+                    f"  rpc {SET_CLAIMS_PROTO_METHOD}"
+                    f"({proto_state.name}{SET_CLAIMS_PROTO_METHOD}"
+                    "Request) returns (google.protobuf.Empty) {\n"
+                    "    option (rbt.v1alpha1.method) = "
+                    "{ transaction: {} };\n"
+                    "  }\n"
+                    f"where '{proto_state.name}"
+                    f"{SET_CLAIMS_PROTO_METHOD}Request' is a message "
+                    "with a 'map<string, google.protobuf.Value> "
+                    "claims = 1;' field."
                 )
 
         return base_services

--- a/reboot/pydantic_schema_to_proto.py
+++ b/reboot/pydantic_schema_to_proto.py
@@ -19,7 +19,16 @@ from reboot.api import (
 )
 from reboot.fail import fail
 from reboot.settings import AUTO_CONSTRUCT_STATE_TYPE
-from typing import Dict, List, Literal, Optional, Union, get_args, get_origin
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union,
+    get_args,
+    get_origin,
+)
 
 # Proto `AutoConstruct` enum value name for per-user
 # auto-construction. Must match the enum in
@@ -38,6 +47,13 @@ def _pydantic_field_type_string_from_type(
     model_name: str,
 ) -> str:
     origin = get_origin(field_type)
+
+    if field_type is Any:
+        # `Any` (e.g. a `dict[str, Any]` value) renders as
+        # `typing.Any`; on the wire it becomes a
+        # `google.protobuf.Value`. We import `typing` as
+        # `IMPORT_typing` to avoid name conflicts in generated code.
+        return 'IMPORT_typing.Any'
 
     if origin is Union or origin is types.UnionType:
         non_none_args = [
@@ -353,6 +369,19 @@ async def generate(
                     required,
                     field_type_string,
                 )
+            elif inner_type is Any:
+                # A bare `Any` field carries an arbitrary JSON value,
+                # just like a `dict[str, Any]` value; both lower to a
+                # `google.protobuf.Value`. `struct.proto` is imported
+                # by every generated file.
+                await _write_field_maybe_with_type_string_annotation(
+                    proto,
+                    proto_field_name,
+                    "google.protobuf.Value",
+                    tag,
+                    required,
+                    field_type_string,
+                )
             elif inner_origin in (list, List):
                 type_name = to_pascal_case(field_name) + "Array"
                 await proto.write(f"  message {type_name} {{\n")
@@ -486,6 +515,11 @@ async def generate(
                 type_name = "double"
             elif value_type == bool:
                 type_name = "bool"
+            elif value_type is Any:
+                # `dict[str, Any]` carries arbitrary JSON values, which
+                # a `google.protobuf.Value` represents; `struct.proto`
+                # is already imported by every generated file.
+                type_name = "google.protobuf.Value"
             elif value_origin in (list, List):
                 type_name = "Value"
                 await proto.write("  message Value {\n")
@@ -556,6 +590,11 @@ async def generate(
                 type_name = "double"
             elif item_type == bool:
                 type_name = "bool"
+            elif item_type is Any:
+                # A `list[Any]` carries arbitrary JSON values; each
+                # element becomes a `google.protobuf.Value`, just like
+                # a `dict[str, Any]` value.
+                type_name = "google.protobuf.Value"
             elif item_origin in (list, List):
                 type_name = "Item"
                 await proto.write("  message Item {\n")

--- a/reboot/pydantic_schema_to_zod.py
+++ b/reboot/pydantic_schema_to_zod.py
@@ -207,6 +207,15 @@ def pydantic_to_zod(
         # Currently only used for methods with no response.
         return 'z.void()'
 
+    if input is Any:
+        # `Any` — e.g. a `dict[str, Any]` map value — accepts any JSON
+        # value. `z.json()` is the schema our `zod-to-proto` converts
+        # to a `google.protobuf.Value`.
+        output = 'z.json()'
+        if tag is not None:
+            output += f'.meta({{ tag: {tag} }})'
+        return output
+
     origin = get_origin(input)
     args = get_args(input)
 

--- a/reboot/pydantic_schema_to_zod.py
+++ b/reboot/pydantic_schema_to_zod.py
@@ -4,6 +4,7 @@ import aiofiles
 import importlib
 import os
 import pydantic_core
+import reboot.api
 import types
 from importlib import import_module
 from pydantic.fields import FieldInfo
@@ -524,6 +525,24 @@ async def generate_zod_file_from_api(
                         external_imports,
                         visited,
                     )
+
+    # `_collect_external_references` above sorted every referenced
+    # `Model` into two buckets: those defined in THIS file, in
+    # `models_in_module` (emitted inline below), and those defined
+    # elsewhere, in `external_imports` (imported from that file's own
+    # generated `.ts`).
+    #
+    # Framework-injected models fit neither: the framework defines them
+    # in `reboot.api` and injects them into the API — e.g. the
+    # `SetClaimsRequest` it adds as the auto-constructed type's
+    # `set_claims` request — so they land in `external_imports` under
+    # `reboot.api`, which is framework Python with no generated `.ts`
+    # to import from (an import for it would dangle and fail to
+    # compile). So treat them like local models: drop them from
+    # `external_imports` (suppressing the bogus import) and append them
+    # to `models_in_module` so their schemas are emitted inline.
+    for model_name in sorted(external_imports.pop(reboot.api.__name__, set())):
+        models_in_module.append(getattr(reboot.api, model_name))
 
     # Build the `external_refs` dict for `Model` name -> import alias.
     external_refs: dict[str, str] = {}

--- a/reboot/settings.py
+++ b/reboot/settings.py
@@ -373,3 +373,14 @@ AUTO_CONSTRUCT_STATE_TYPE = "User"
 # Constructor method name for auto-constructed state types.
 AUTO_CONSTRUCT_METHOD = "create"  # As used in Python.
 AUTO_CONSTRUCT_PROTO_METHOD = "Create"  # As used in protobuf.
+
+# Name of the claims-delivery method the framework injects on
+# auto-constructed state types: a transaction through which the
+# framework delivers the user's verified identity claims (see the
+# generated `set_claims` servicer method). The proto-level name is a
+# wire contract: the cloud controller validates every deployed
+# application's descriptors for backwards compatibility on upgrade and
+# rejects a deleted (renamed) method, and replicas of different
+# versions exchange RPCs by this name during rolling deploys.
+SET_CLAIMS_METHOD = "set_claims"  # As used in Python.
+SET_CLAIMS_PROTO_METHOD = "SetClaims"  # As used in protobuf.

--- a/reboot/templates/reboot.py.j2
+++ b/reboot/templates/reboot.py.j2
@@ -2717,7 +2717,7 @@ class {{ state.proto.name }}BaseServicer(IMPORT_reboot_aio_servicers.Servicer):
 {% endif %}
 {% if state.proto.auto_construct != AUTO_CONSTRUCT_UNSPECIFIED %}
             # State is auto-constructed when the user's
-            # JWT is minted; see `_auto_construct`.
+            # JWT is minted; see `_authenticated`.
 {% endif %}
 {% if method.options.proto.constructor %}
 {% if method.input_type_fields %}
@@ -2773,7 +2773,7 @@ class {{ state.proto.name }}BaseServicer(IMPORT_reboot_aio_servicers.Servicer):
 {% endif %}
 {% if state.proto.auto_construct != AUTO_CONSTRUCT_UNSPECIFIED %}
             # State is auto-constructed when the user's
-            # JWT is minted; see `_auto_construct`.
+            # JWT is minted; see `_authenticated`.
 {% endif %}
             # Construct request from URI params, coercing types
             # as needed.
@@ -2820,7 +2820,7 @@ class {{ state.proto.name }}BaseServicer(IMPORT_reboot_aio_servicers.Servicer):
 {% endif %}
 {% if state.proto.auto_construct != AUTO_CONSTRUCT_UNSPECIFIED %}
             # State is auto-constructed when the user's
-            # JWT is minted; see `_auto_construct`.
+            # JWT is minted; see `_authenticated`.
 {% endif %}
 {% if method.options.proto.constructor %}
             _, response = await {{ state.proto.name }}.{{ method.proto.name }}(reboot_context, {{ mcp_name_prefix }}id)
@@ -3086,18 +3086,29 @@ class {{ state.proto.name }}BaseServicer(IMPORT_reboot_aio_servicers.Servicer):
 
 {% if state.proto.auto_construct != AUTO_CONSTRUCT_UNSPECIFIED %}
     @staticmethod
-    async def _auto_construct(
+    async def _authenticated(
         context: IMPORT_reboot_aio_external.ExternalContext,
         state_id: str,
+        claims: IMPORT_typing.Optional[
+            IMPORT_typing.Mapping[str, IMPORT_typing.Any]
+        ] = None,
     ) -> None:
-        """Auto-construct a `{{ state.proto.name }}` state."""
-        # Some states have `_auto_construct` called many times, e.g. a
-        # per-user state may get auto-constructed at the start of every
-        # MCP session. We derive a deterministic idempotency key from the
-        # state ID so that repeated calls (even from different contexts)
-        # are a NOOP. We prefer this over catching the
-        # `StateAlreadyExists` error that would otherwise result, since
-        # that logs an `ERROR` to user-visible logs.
+        """Record that a user authenticated: construct their
+        `{{ state.proto.name }}` if it does not exist yet, then, when
+        `claims` is given, deliver their verified identity claims.
+
+        `claims=None` means the caller has no claims information for
+        this authentication (e.g. a token refresh, which never
+        consults the identity provider); it never means "no claims"
+        and never clears previously delivered claims.
+        """
+        # A `{{ state.proto.name }}` may be authenticated many times,
+        # e.g. a per-user state on every sign-in. We derive a
+        # deterministic idempotency key from the state ID so that the
+        # construct is a NOOP once the state exists (even across
+        # different contexts). We prefer this over catching the
+        # `StateAlreadyConstructed` error that would otherwise result,
+        # since that logs an `ERROR` to user-visible logs.
         idempotency_key = IMPORT_uuid.uuid5(
             IMPORT_uuid.NAMESPACE_URL,
             f"urn:dev.reboot:auto-construct:{{ state.proto.name }}:{state_id}",
@@ -3105,6 +3116,18 @@ class {{ state.proto.name }}BaseServicer(IMPORT_reboot_aio_servicers.Servicer):
         await {{ state.proto.name }}.idempotently(
             key=idempotency_key,
         ).{{ AUTO_CONSTRUCT_METHOD }}(context, state_id)
+        # The two calls are deliberately sequential rather than wrapped
+        # in one transaction: an idempotent construct followed by a
+        # full-replace `{{ SET_CLAIMS_METHOD }}` compose convergently.
+        # `{{ SET_CLAIMS_METHOD }}` runs on every sign-in (`.always()`)
+        # because even if `set_state(claims=FOO)` has been called before,
+        # it could be that `set_state(claims=BAR)` was called since
+        # then, and `set_state(claims=FOO)` would have an effect again -
+        # we want to converge on the most recently delivered claims.
+        if claims is not None:
+            await {{ state.proto.name }}.ref(state_id).always().{{ SET_CLAIMS_METHOD }}(
+                context, claims=claims
+            )
 {% endif %}
 
     def ref(

--- a/reboot/templates/reboot.py.j2
+++ b/reboot/templates/reboot.py.j2
@@ -3828,8 +3828,9 @@ class {{ state.proto.name }}SingletonServicer({{ state.proto.name }}BaseServicer
     # Override in your Servicer to run custom initialization
     # on new {{ state.proto.name }} instances.
     {% else %}
-    # Concrete no-op default for `{{ SET_CLAIMS_METHOD }}`. You may 
-    # override it in your Servicer to use the delivered claims.
+    # Default `{{ SET_CLAIMS_METHOD }}` that raises when verified
+    # identity claims are delivered but your Servicer hasn't
+    # overridden it. Override it to consume the delivered claims.
     {% endif %}
     async def {{ method.proto.name }}(
         self,
@@ -3864,8 +3865,18 @@ class {{ state.proto.name }}SingletonServicer({{ state.proto.name }}BaseServicer
         This makes the method idempotent — re-delivering the same
         claims is harmless — which is required, since it runs on
         every sign-in, not just the first."""
-        {% endif %}
+        raise NotImplementedError(
+            "Verified identity claims were delivered for this "
+            "`{{ state.proto.name }}`, but its servicer does not "
+            "override `{{ SET_CLAIMS_METHOD }}`, so the claims would "
+            "be discarded. Override `{{ SET_CLAIMS_METHOD }}` to "
+            "derive `{{ state.proto.name }}` state from "
+            "`request.claims`, or stop requesting claims from your "
+            "identity provider."
+        )
+        {% else %}
         pass
+        {% endif %}
     {% else %}
     # To be backwards compatible during the renaming don't make this
     # method to be 'abstractmethod', so that new code that
@@ -4146,8 +4157,9 @@ class {{ state.proto.name }}Servicer({{ state.proto.name }}BaseServicer):
     # Override in your Servicer to run custom initialization
     # on new {{ state.proto.name }} instances.
     {% else %}
-    # Concrete no-op default for `{{ SET_CLAIMS_METHOD }}`. You may 
-    # override it in your Servicer to use the delivered claims.
+    # Default `{{ SET_CLAIMS_METHOD }}` that raises when verified
+    # identity claims are delivered but your Servicer hasn't
+    # overridden it. Override it to consume the delivered claims.
     {% endif %}
     async def {{ method.proto.name }}(
         self,
@@ -4179,8 +4191,18 @@ class {{ state.proto.name }}Servicer({{ state.proto.name }}BaseServicer):
         This makes the method idempotent — re-delivering the same
         claims is harmless — which is required, since it runs on
         every sign-in, not just the first."""
-        {% endif %}
+        raise NotImplementedError(
+            "Verified identity claims were delivered for this "
+            "`{{ state.proto.name }}`, but its servicer does not "
+            "override `{{ SET_CLAIMS_METHOD }}`, so the claims would "
+            "be discarded. Override `{{ SET_CLAIMS_METHOD }}` to "
+            "derive `{{ state.proto.name }}` state from "
+            "`request.claims`, or stop requesting claims from your "
+            "identity provider."
+        )
+        {% else %}
         pass
+        {% endif %}
     {% else %}
     # To be backwards compatible during the renaming don't make this
     # method to be 'abstractmethod', so that new code that

--- a/reboot/templates/reboot.py.j2
+++ b/reboot/templates/reboot.py.j2
@@ -16,6 +16,8 @@ reported in user code. #}
 {% set AUTO_CONSTRUCT_PER_USER_ID = 1 %}
 {% set AUTO_CONSTRUCT_PROTO_METHOD = "Create" %}
 {% set AUTO_CONSTRUCT_METHOD = "create" %}
+{% set SET_CLAIMS_PROTO_METHOD = "SetClaims" %}
+{% set SET_CLAIMS_METHOD = "set_claims" %}
 
 {# Determine whether or not we'll be overriding 'Read'/'Write'. #}
 {% for client in clients %}
@@ -1736,6 +1738,29 @@ class {{ state.proto.name }}ServicerMiddleware(IMPORT_reboot_aio_internals_middl
                 context_type=IMPORT_reboot_aio_contexts.ReaderContext,
             ) as context:
                 context.auth = auth
+                {% if state.proto.auto_construct != AUTO_CONSTRUCT_UNSPECIFIED %}
+
+                # The framework's `set_claims` method should only ever
+                # be app-internal; even the owning user shouldn't be
+                # trusted to call it, since the identity provider's
+                # claims may deliver info like "validated email address"
+                # and other things we don't trust the user to set
+                # directly.
+                #
+                # This extra app-internal check comes before any
+                # authorizer, so no authorizer — including a blanket
+                # `allow()` — can expose the method to external callers.
+                if (
+                    method_name.split('.')[-1] == '{{ SET_CLAIMS_PROTO_METHOD }}'
+                    and not context.app_internal
+                ):
+                    raise IMPORT_reboot.aio.aborted.SystemAborted(
+                        IMPORT_rbt_v1alpha1.errors_pb2.PermissionDenied(),
+                        message=
+                        f"You are not authorized to call '{method_name}' on "
+                        f"`{{ state.proto.full_name }}('{headers.state_ref.id}')`"
+                    )
+                {% endif %}
 
                 # Get the authorizer decision.
                 authorization_decision = await self._authorizer.authorize(
@@ -3774,10 +3799,15 @@ class {{ state.proto.name }}SingletonServicer({{ state.proto.name }}BaseServicer
     ) -> {% if method.has_non_none_response %}{{ state.proto.name }}.{{ method.proto.name }}Response{% else %}None{% endif %}:
         raise NotImplementedError
     {% elif method.options.proto.kind == 'transaction' %}
-    {% if method.proto.name == AUTO_CONSTRUCT_PROTO_METHOD and state.proto.auto_construct != AUTO_CONSTRUCT_UNSPECIFIED %}
+    {% if state.proto.auto_construct != AUTO_CONSTRUCT_UNSPECIFIED and method.proto.name in [AUTO_CONSTRUCT_PROTO_METHOD, SET_CLAIMS_PROTO_METHOD] %}
+    {% if method.proto.name == AUTO_CONSTRUCT_PROTO_METHOD %}
     # Concrete no-op default for `{{ AUTO_CONSTRUCT_METHOD }}`.
     # Override in your Servicer to run custom initialization
     # on new {{ state.proto.name }} instances.
+    {% else %}
+    # Concrete no-op default for `{{ SET_CLAIMS_METHOD }}`. You may 
+    # override it in your Servicer to use the delivered claims.
+    {% endif %}
     async def {{ method.proto.name }}(
         self,
         context: IMPORT_reboot_aio_contexts.TransactionContext,
@@ -3786,7 +3816,13 @@ class {{ state.proto.name }}SingletonServicer({{ state.proto.name }}BaseServicer
         request: {{ state.proto.name}}.{{ method.proto.name }}Request,
         {% endif %}
     ) -> {% if method.has_non_none_response %}{{ state.proto.name }}.{{ method.proto.name }}Response{% else %}None{% endif %}:
-        pass
+        return await self.{{ method.proto.name | to_snake }}(
+            context,
+            state,
+            {% if method.has_non_none_request %}
+            request,
+            {% endif %}
+        )
 
     async def {{ method.proto.name | to_snake }}(
         self,
@@ -3796,6 +3832,16 @@ class {{ state.proto.name }}SingletonServicer({{ state.proto.name }}BaseServicer
         request: {{ state.proto.name}}.{{ method.proto.name }}Request,
         {% endif %}
     ) -> {% if method.has_non_none_response %}{{ state.proto.name }}.{{ method.proto.name }}Response{% else %}None{% endif %}:
+        {% if method.proto.name == SET_CLAIMS_PROTO_METHOD %}
+        """The framework calls this on every sign-in to deliver the
+        user's verified identity claims. `request.claims` is the
+        complete, current set of verified claims (a `dict[str, Any]`
+        keyed by claim name); treat it as a full replace and fully
+        derive any claim-backed {{ state.proto.name }} state from it.
+        This makes the method idempotent — re-delivering the same
+        claims is harmless — which is required, since it runs on
+        every sign-in, not just the first."""
+        {% endif %}
         pass
     {% else %}
     # To be backwards compatible during the renaming don't make this
@@ -4069,12 +4115,17 @@ class {{ state.proto.name }}Servicer({{ state.proto.name }}BaseServicer):
     {% for service in state.services %}
     {% for method in service.methods %}
     # For '{{ method.proto.full_name }}'.
-    {% if method.proto.name == AUTO_CONSTRUCT_PROTO_METHOD and state.proto.auto_construct != AUTO_CONSTRUCT_UNSPECIFIED %}
+    {% if state.proto.auto_construct != AUTO_CONSTRUCT_UNSPECIFIED and method.proto.name in [AUTO_CONSTRUCT_PROTO_METHOD, SET_CLAIMS_PROTO_METHOD] %}
+    {% if method.proto.name == AUTO_CONSTRUCT_PROTO_METHOD %}
     # Concrete no-op default for `{{ AUTO_CONSTRUCT_METHOD }}`. The
     # auto-constructed `{{ AUTO_CONSTRUCT_METHOD }}` is always a
     # `Transaction` (see `api.py`), so it takes a `TransactionContext`.
     # Override in your Servicer to run custom initialization
     # on new {{ state.proto.name }} instances.
+    {% else %}
+    # Concrete no-op default for `{{ SET_CLAIMS_METHOD }}`. You may 
+    # override it in your Servicer to use the delivered claims.
+    {% endif %}
     async def {{ method.proto.name }}(
         self,
         context: IMPORT_reboot_aio_contexts.TransactionContext,
@@ -4096,6 +4147,16 @@ class {{ state.proto.name }}Servicer({{ state.proto.name }}BaseServicer):
         request: {{ state.proto.name }}.{{ method.proto.name }}Request,
         {% endif %}
     ) -> {% if method.has_non_none_response %}{{ state.proto.name }}.{{ method.proto.name }}Response{% else %}None{% endif %}:
+        {% if method.proto.name == SET_CLAIMS_PROTO_METHOD %}
+        """The framework calls this on every sign-in to deliver the
+        user's verified identity claims. `request.claims` is the
+        complete, current set of verified claims (a `dict[str, Any]`
+        keyed by claim name); treat it as a full replace and fully
+        derive any claim-backed {{ state.proto.name }} state from it.
+        This makes the method idempotent — re-delivering the same
+        claims is harmless — which is required, since it runs on
+        every sign-in, not just the first."""
+        {% endif %}
         pass
     {% else %}
     # To be backwards compatible during the renaming don't make this

--- a/tests/reboot/aio/applications_test.py
+++ b/tests/reboot/aio/applications_test.py
@@ -283,7 +283,7 @@ class TestCase(unittest.IsolatedAsyncioTestCase):
             name=f"fallthrough-{self.id()}",
             bearer_token="carol",
         )
-        await UserServicer._auto_construct(
+        await UserServicer._authenticated(
             custom_context,
             state_id="carol",
         )

--- a/tests/reboot/aio/auth/BUILD.bazel
+++ b/tests/reboot/aio/auth/BUILD.bazel
@@ -19,6 +19,7 @@ py_test(
         "//reboot/std/ciphertext/v1:ciphertext_py",
         "//reboot/std/collections/ordered_map/v1:ordered_map_py",
         "//reboot/std/oauth/v1:oauth_py",
+        "//tests/reboot/pydantic/auto_construct_user:servicer_py",
         "@com_github_reboot_dev_reboot//rbt/std/oauth/v1:oauth_py_reboot",
         requirement("httpx"),
         requirement("mcp"),

--- a/tests/reboot/aio/auth/auto_supplied_oauth_test.py
+++ b/tests/reboot/aio/auth/auto_supplied_oauth_test.py
@@ -63,9 +63,9 @@ class AutoSuppliedOAuthWithCustomVerifierTest(
     ) -> None:
         # `create_external_context_as` mints a token through the
         # auto-supplied OAuth server's production chokepoint, whose
-        # post-authenticate hook auto-constructs alice's `User` as a
+        # `_authenticated` hook auto-constructs alice's `User` as a
         # side effect — so `whoami` finds her actor without any
-        # explicit `_auto_construct` call here.
+        # explicit `_authenticated` call here.
         context = await self.rbt.create_external_context_as(
             name="alice",
             user_id="alice",
@@ -79,7 +79,7 @@ class AutoSuppliedOAuthWithCustomVerifierTest(
         # to `CustomTokenVerifier`, which authenticates user "bob". No
         # mint happened for bob, so construct his `User` explicitly.
         context = self._context_as("bob", "custom-token-bob")
-        await UserServicer._auto_construct(context, state_id="bob")
+        await UserServicer._authenticated(context, state_id="bob")
 
         response = await User.ref("bob").whoami(context)
         self.assertEqual(response.user_id, "bob")

--- a/tests/reboot/aio/auth/compound_token_verifier_test.py
+++ b/tests/reboot/aio/auth/compound_token_verifier_test.py
@@ -70,7 +70,7 @@ class CompoundTokenVerifierTest(unittest.IsolatedAsyncioTestCase):
         # opinion and the token falls through to
         # `_BearerIsUserIdForTest`, which authenticates user "bob".
         context = self._context_as("bob", "bob")
-        await UserServicer._auto_construct(context, state_id="bob")
+        await UserServicer._authenticated(context, state_id="bob")
 
         response = await User.ref("bob").whoami(context)
         self.assertEqual(response.user_id, "bob")

--- a/tests/reboot/aio/auth/oauth_providers_test.py
+++ b/tests/reboot/aio/auth/oauth_providers_test.py
@@ -35,6 +35,12 @@ from reboot.std.collections.ordered_map.v1.ordered_map import (
     ordered_map_library,
 )
 from reboot.std.oauth.v1.oauth import oauth_library
+from tests.reboot.pydantic.auto_construct_user.servicer import \
+    ProfileServicer as AutoConstructProfileServicer
+from tests.reboot.pydantic.auto_construct_user.servicer import \
+    UserServicer as AutoConstructUserServicer
+from tests.reboot.pydantic.auto_construct_user.servicer_api_rbt import \
+    User as AutoConstructUser
 from typing import Any, Mapping, Optional
 from unittest import mock
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -2308,6 +2314,116 @@ class OAuthProviderForTestSelectorTest(unittest.TestCase):
         with self.assertRaises(InputError) as context:
             selector.get()
         self.assertIn("Google", str(context.exception))
+
+
+class _FakeClaimsProvider(OAuthProvider):
+    """A provider that redirects straight back to the callback and
+    reports a fixed user with whatever claims a test assigns, so
+    claims delivery can be exercised across successive sign-ins."""
+
+    USER_ID = UserId("claims-user")
+
+    def __init__(self) -> None:
+        super().__init__()
+        # The claims the next `exchange_code` reports; `None` means
+        # the provider has no verified claims source.
+        self.claims: Optional[Mapping[str, Any]] = None
+
+    def authorization_url(self, state: str, redirect_uri: str) -> str:
+        return f"{redirect_uri}?{urlencode({'code': 'fake', 'state': state})}"
+
+    async def exchange_code(
+        self, code: str, redirect_uri: str
+    ) -> ExchangeResult:
+        return ExchangeResult(
+            user_id=self.USER_ID,
+            tokens=None,
+            claims=self.claims,
+        )
+
+
+class ClaimsDeliveryTest(unittest.IsolatedAsyncioTestCase):
+    """Drives browser sign-ins with a fake provider and checks how the
+    exchange's claims reach `User` state: a mapping is delivered as a
+    full replacement (so an empty mapping clears previously delivered
+    claims), while `None` delivers nothing and clears nothing."""
+
+    async def asyncSetUp(self) -> None:
+        self.rbt = Reboot()
+        await self.rbt.start()
+        self.provider = _FakeClaimsProvider()
+        await self.rbt.up(
+            Application(
+                servicers=[
+                    AutoConstructUserServicer,
+                    AutoConstructProfileServicer,
+                ],
+                oauth=OAuthProviderForTest(self.provider),
+            ),
+        )
+
+    async def asyncTearDown(self) -> None:
+        await self.rbt.stop()
+
+    async def _login(self) -> None:
+        """Drive one full browser sign-in (start → authorize →
+        callback → finish) with a fresh cookie jar, so every login
+        performs a real identity-provider code exchange instead of
+        being short-circuited by session-cookie SSO."""
+        base = self.rbt.http_localhost_url("")
+        async with httpx.AsyncClient(
+            follow_redirects=False,
+            cookies=httpx.Cookies(),
+        ) as client:
+
+            def strip_secure_flag_from_cookies() -> None:
+                # The OAuth server marks all browser-flow cookies
+                # `Secure`, which browsers exempt for `localhost` but
+                # httpx's cookie jar does not.
+                for cookie in client.cookies.jar:
+                    cookie.secure = False
+
+            response = await client.get(
+                base + "/__/oauth/start",
+                params={"return_to": "/"},
+            )
+            # start → authorize → (the fake provider redirects
+            # straight back to) callback → finish → `return_to`.
+            for _ in range(4):
+                strip_secure_flag_from_cookies()
+                self.assertEqual(response.status_code, 302, response.text)
+                location = response.headers["location"]
+                if location == "/":
+                    return
+                response = await client.get(location)
+            self.assertEqual(response.headers["location"], "/")
+
+    async def test_claims_full_replace_and_none_delivers_nothing(self) -> None:
+        context = self.rbt.create_external_context(
+            name=f"test-{self.id()}",
+            app_internal=True,
+        )
+        user = AutoConstructUser.ref(_FakeClaimsProvider.USER_ID)
+
+        # A mapping is delivered as the complete current claim set.
+        self.provider.claims = {"email": "first@example.com"}
+        await self._login()
+        response = await user.get(context)
+        self.assertEqual(response.email, "first@example.com")
+
+        # `None`: the provider has no verified claims source, so
+        # nothing is delivered and nothing is cleared.
+        self.provider.claims = None
+        await self._login()
+        response = await user.get(context)
+        self.assertEqual(response.email, "first@example.com")
+
+        # An empty mapping is still the complete current claim set:
+        # the full replacement clears previously delivered claims.
+        self.provider.claims = {}
+        await self._login()
+        response = await user.get(context)
+        self.assertEqual(response.email, "")
 
 
 if __name__ == "__main__":

--- a/tests/reboot/aio/auth/oauth_providers_test.py
+++ b/tests/reboot/aio/auth/oauth_providers_test.py
@@ -21,6 +21,7 @@ from reboot.aio.auth.oauth_providers import (
     Google,
     OAuthProvider,
     OAuthProviderByEnvironment,
+    RegisteredOAuthProvider,
     UserId,
 )
 from reboot.aio.auth.token_verifiers import TokenVerifier, VerifyTokenResult
@@ -34,7 +35,7 @@ from reboot.std.collections.ordered_map.v1.ordered_map import (
     ordered_map_library,
 )
 from reboot.std.oauth.v1.oauth import oauth_library
-from typing import Optional
+from typing import Any, Mapping, Optional
 from unittest import mock
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -867,6 +868,58 @@ class DevelopmentOAuthProviderTest(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(response.status_code, 400)
                 self.assertNotIn("Alice", response.text)
 
+    async def test_development_exchange_fabricates_identity_claims(self):
+        """
+        `Development(claims=...)` fabricates the requested identity
+        claims a real provider would deliver — matching the identity
+        shown on its login page — so claims-consuming application code
+        can be exercised locally. Without `claims=` it delivers none,
+        and a mapping presents a claim under a different name.
+        """
+        # Bring up a cluster so the Reboot-managed crypto root keys the
+        # dev user-id derivation uses are in place.
+        await self.rbt.up(
+            Application(
+                servicers=[UserServicer, CounterServicer],
+                oauth=OAuthProviderForTest(Development()),
+            ),
+        )
+        result = await Development(
+            claims=["email", "email_verified", "name"],
+        ).exchange_code(
+            code="Alice",
+            redirect_uri="http://localhost/cb",
+        )
+        self.assertEqual(
+            result.claims,
+            {
+                "email": "alice@example.com",
+                "email_verified": True,
+                "name": "Alice",
+            },
+        )
+
+        # Without `claims=`, claim delivery is off entirely.
+        result = await Development().exchange_code(
+            code="Alice",
+            redirect_uri="http://localhost/cb",
+        )
+        self.assertIsNone(result.claims)
+
+        # A mapping presents a claim under a different name.
+        result = await Development(
+            claims={
+                "email": "verified-email"
+            },
+        ).exchange_code(
+            code="Alice",
+            redirect_uri="http://localhost/cb",
+        )
+        self.assertEqual(
+            result.claims,
+            {"verified-email": "alice@example.com"},
+        )
+
 
 class _NoOpTokenVerifier(TokenVerifier):
     """A `token_verifier=` that has no opinion on any token. Enough to
@@ -1271,6 +1324,162 @@ class GitHubValidateTest(unittest.TestCase):
         self.assertIn("`client_secret`", str(context.exception))
 
 
+class _FakeAiohttpResponse:
+    """A canned JSON response, shaped like an `aiohttp` request
+    context manager."""
+
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    async def __aenter__(self) -> "_FakeAiohttpResponse":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        pass
+
+    async def json(self) -> Any:
+        return self._payload
+
+
+class _FakeAiohttpSession:
+    """Just enough of `aiohttp.ClientSession` for a GitHub code
+    exchange: canned JSON responses keyed by URL, recording the URLs
+    requested."""
+
+    def __init__(self, responses: Mapping[str, Any]) -> None:
+        self._responses = responses
+        self.requested_urls: list[str] = []
+
+    async def __aenter__(self) -> "_FakeAiohttpSession":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    def post(self, url: str, **kwargs: Any) -> _FakeAiohttpResponse:
+        self.requested_urls.append(url)
+        return _FakeAiohttpResponse(self._responses[url])
+
+    def get(self, url: str, **kwargs: Any) -> _FakeAiohttpResponse:
+        self.requested_urls.append(url)
+        return _FakeAiohttpResponse(self._responses[url])
+
+
+class GitHubEmailClaimsTest(unittest.IsolatedAsyncioTestCase):
+    """`GitHub(claims=...)` resolves the email claims via
+    `GET /user/emails` — never the `GET /user` `email` field, which
+    is the user-chosen public profile email and may be unverified —
+    delivering the user's primary address only when GitHub has
+    verified it."""
+
+    _TOKEN_URL = "https://github.com/login/oauth/access_token"
+    _USER_URL = "https://api.github.com/user"
+    _EMAILS_URL = "https://api.github.com/user/emails"
+
+    async def _exchange(
+        self,
+        provider: GitHub,
+        emails: Any,
+    ) -> tuple[ExchangeResult, _FakeAiohttpSession]:
+        session = _FakeAiohttpSession(
+            {
+                self._TOKEN_URL: {
+                    "access_token": "gh-token"
+                },
+                self._USER_URL:
+                    {
+                        "id": 12345,
+                        # The public profile email: possibly unverified,
+                        # so it must never become a claim.
+                        "email": "public-profile@example.com",
+                    },
+                self._EMAILS_URL: emails,
+            }
+        )
+        with mock.patch("aiohttp.ClientSession", return_value=session):
+            result = await provider.exchange_code(
+                code="c",
+                redirect_uri="http://localhost/cb",
+            )
+        return result, session
+
+    def _github(self, **kwargs: Any) -> GitHub:
+        return GitHub(client_id="id", client_secret="s", **kwargs)
+
+    async def test_verified_primary_email_delivered(self):
+        result, _ = await self._exchange(
+            self._github(claims=["email", "email_verified"]),
+            [
+                {
+                    "email": "secondary@example.com",
+                    "primary": False,
+                    "verified": True,
+                },
+                {
+                    "email": "jane@example.com",
+                    "primary": True,
+                    "verified": True,
+                },
+            ],
+        )
+        self.assertEqual(
+            result.claims,
+            {
+                "email": "jane@example.com",
+                "email_verified": True,
+            },
+        )
+
+    async def test_unverified_primary_email_delivers_no_email_claims(self):
+        # The primary address is the user's canonical one; when it is
+        # unverified there is no verified email to assert — even if
+        # some secondary address is verified — so the claim set is
+        # empty (a full replace that clears any previously delivered
+        # email).
+        result, _ = await self._exchange(
+            self._github(claims=["email", "email_verified"]),
+            [
+                {
+                    "email": "secondary@example.com",
+                    "primary": False,
+                    "verified": True,
+                },
+                {
+                    "email": "jane@example.com",
+                    "primary": True,
+                    "verified": False,
+                },
+            ],
+        )
+        self.assertEqual(result.claims, {})
+
+    async def test_email_claim_presented_under_mapped_name(self):
+        result, _ = await self._exchange(
+            self._github(claims={"email": "verified-email"}),
+            [
+                {
+                    "email": "jane@example.com",
+                    "primary": True,
+                    "verified": True,
+                },
+            ],
+        )
+        self.assertEqual(
+            result.claims,
+            {"verified-email": "jane@example.com"},
+        )
+
+    async def test_no_claims_requested_skips_email_lookup(self):
+        result, session = await self._exchange(self._github(), [])
+        self.assertIsNone(result.claims)
+        # No claims were requested, so the extra API round trip never
+        # happens.
+        self.assertNotIn(self._EMAILS_URL, session.requested_urls)
+
+
 class Auth0ValidateTest(unittest.TestCase):
     """
     Same shape as `GoogleValidateTest`/`GitHubValidateTest`, plus the
@@ -1348,6 +1557,194 @@ class Auth0DomainTest(unittest.TestCase):
         self.assertTrue(url.startswith("https://tenant.auth0.com/authorize?"))
 
 
+class RequestedClaimsTest(unittest.TestCase):
+    """The `claims=` a provider is constructed with decides exactly
+    what `_presented_claims` lets out of a decoded ID token (or
+    userinfo response): only the requested claims, under their
+    presented names — so ephemeral protocol claims (`exp`, `nonce`,
+    ...) never leak into `ExchangeResult.claims`, where they would
+    make every sign-in look like a claims change. Requests a provider
+    cannot serve fail at construction."""
+
+    def _google(self, **kwargs: Any) -> Google:
+        return Google(client_id="id", client_secret="s", **kwargs)
+
+    def test_filters_to_requested_claims(self):
+        self.assertEqual(
+            self._google(
+                claims=["email", "email_verified", "name"],
+            )._presented_claims(
+                {
+                    "iss": "https://idp.example",
+                    "sub": "user-123",
+                    "aud": "client-id",
+                    "exp": 1999999999,
+                    "iat": 1999990000,
+                    "nonce": "abc",
+                    "email": "jane@example.com",
+                    "email_verified": True,
+                    "name": "Jane Doe",
+                }
+            ),
+            {
+                "email": "jane@example.com",
+                "email_verified": True,
+                "name": "Jane Doe",
+            },
+        )
+
+    def test_unrequested_claims_stay_inside_the_provider(self):
+        self.assertEqual(
+            self._google(claims=["email"])._presented_claims(
+                {
+                    "email": "jane@example.com",
+                    "name": "Jane Doe",
+                }
+            ),
+            {"email": "jane@example.com"},
+        )
+
+    def test_mapping_presents_claims_under_new_names(self):
+        self.assertEqual(
+            self._google(
+                claims={
+                    "email": "verified-email",
+                    "name": "name",
+                },
+            )._presented_claims(
+                {
+                    "email": "jane@example.com",
+                    "name": "Jane Doe",
+                }
+            ),
+            {
+                "verified-email": "jane@example.com",
+                "name": "Jane Doe",
+            },
+        )
+
+    def test_no_claims_requested_presents_none(self):
+        # `None`, not `{}`: claim delivery is off, as opposed to
+        # asserting a verified-empty claim set.
+        self.assertIsNone(
+            self._google()._presented_claims({"email": "jane@example.com"}),
+        )
+
+    def test_omits_absent_and_none_claims(self):
+        self.assertEqual(
+            self._google(
+                claims=["email", "name"],
+            )._presented_claims({
+                "email": "jane@example.com",
+                "name": None,
+            }),
+            {"email": "jane@example.com"},
+        )
+
+    def test_false_valued_claims_are_kept(self):
+        # `email_verified: false` is a meaningful claim value, distinct
+        # from the claim being absent.
+        self.assertEqual(
+            self._google(
+                claims=["email_verified"],
+            )._presented_claims({"email_verified": False}),
+            {"email_verified": False},
+        )
+
+    def test_unavailable_claim_rejected_naming_available_ones(self):
+        with self.assertRaises(InputError) as context:
+            self._google(claims=["email", "phone_number"])
+        message = str(context.exception)
+        self.assertIn("Google", message)
+        self.assertIn("'phone_number'", message)
+        # The message names the claims that ARE available.
+        self.assertIn("'email'", message)
+        self.assertIn("'email_verified'", message)
+        self.assertIn("'name'", message)
+
+    def test_claimless_provider_rejects_any_claims(self):
+        # A provider with no claims vocabulary at all rejects every
+        # `claims=` request.
+        class Claimless(RegisteredOAuthProvider):
+            _REQUIRED_SCOPE = "basic"
+
+            def authorization_url(
+                self,
+                state: str,
+                redirect_uri: str,
+            ) -> str:
+                raise NotImplementedError()
+
+            async def exchange_code(
+                self,
+                code: str,
+                redirect_uri: str,
+            ) -> ExchangeResult:
+                raise NotImplementedError()
+
+        with self.assertRaises(InputError) as context:
+            Claimless(client_id="id", client_secret="s", claims=["email"])
+        self.assertIn("Claimless", str(context.exception))
+        self.assertIn("does not deliver", str(context.exception))
+
+    def test_github_rejects_claims_it_cannot_deliver(self):
+        # GitHub's menu is intentionally limited to the verified
+        # email claims until the integration is easier to test, so
+        # `name` is not on it (see `GitHub._AVAILABLE_CLAIMS`).
+        with self.assertRaises(InputError) as context:
+            GitHub(client_id="id", client_secret="s", claims=["name"])
+        message = str(context.exception)
+        self.assertIn("GitHub", message)
+        self.assertIn("'name'", message)
+        self.assertIn("'email'", message)
+
+    def test_bare_string_rejected(self):
+        # A bare string is a `Sequence[str]` of characters; catch the
+        # mistake instead of requesting claims 'e', 'm', 'a', ...
+        with self.assertRaises(InputError) as context:
+            self._google(claims="email")
+        self.assertIn("'email'", str(context.exception))
+
+    def test_non_string_claim_entries_rejected(self):
+        # Malformed `claims=` values fail with the same
+        # construction-time diagnostics as unknown claims, not a raw
+        # `TypeError` from further down.
+        with self.assertRaises(InputError) as context:
+            self._google(claims=[["email"]])
+        self.assertIn("non-string", str(context.exception))
+        with self.assertRaises(InputError) as context:
+            self._google(claims={"email": ["alias"]})
+        self.assertIn("non-string", str(context.exception))
+
+    def test_duplicate_presented_names_rejected(self):
+        with self.assertRaises(InputError) as context:
+            self._google(
+                claims={
+                    "email": "contact",
+                    "name": "contact",
+                },
+            )
+        self.assertIn("'contact'", str(context.exception))
+
+    def test_empty_claims_means_none(self):
+        self.assertIsNone(
+            self._google(claims=[])._presented_claims({"email": "x"}),
+        )
+
+
+class AnonymousClaimsTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_anonymous_exchange_has_no_claims(self):
+        # An anonymous user has no verified identity to draw claims
+        # from: the provider has no claims source at all (`None`), as
+        # opposed to asserting a verified-empty claim set (`{}`).
+        result = await Anonymous().exchange_code(
+            code="anonymous",
+            redirect_uri="http://localhost/cb",
+        )
+        self.assertIsNone(result.claims)
+
+
 def _scope_param(authorization_url: str) -> list[str]:
     """Extract the space-delimited `scope` query parameter from an
     authorization URL as a list."""
@@ -1356,10 +1753,11 @@ def _scope_param(authorization_url: str) -> list[str]:
 
 
 class ScopeTest(unittest.TestCase):
-    """`Google`/`GitHub` always request their required base scope and add
-    any developer-supplied `scopes` on top — so an app can ask for extra
-    access (Calendar, `repo`, …) without losing the scope identity
-    resolution depends on."""
+    """`Google`/`GitHub` always request their required base scope and
+    add the scopes any requested `claims=` need plus any
+    developer-supplied `scopes` on top — so an app can ask for
+    identity claims and extra access (Calendar, `repo`, …) without
+    losing the scope identity resolution depends on."""
 
     def test_google_defaults_to_openid_only(self):
         url = Google(client_id="id", client_secret="s").authorization_url(
@@ -1377,6 +1775,28 @@ class ScopeTest(unittest.TestCase):
         scopes = _scope_param(url)
         self.assertEqual(scopes[0], "openid")
         self.assertIn(calendar, scopes)
+
+    def test_google_derives_scopes_from_requested_claims(self):
+        # Requesting claims requests the scopes that make the identity
+        # provider deliver them, without the developer having to know
+        # the claim-to-scope mapping.
+        url = Google(
+            client_id="id",
+            client_secret="s",
+            claims=["email", "email_verified", "name"],
+        ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+        self.assertEqual(_scope_param(url), ["openid", "email", "profile"])
+
+    def test_claim_derived_scopes_are_deduplicated(self):
+        # A claim-derived scope the developer also asked for via
+        # `scopes=` appears once.
+        url = Google(
+            client_id="id",
+            client_secret="s",
+            scopes=["email"],
+            claims=["email"],
+        ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+        self.assertEqual(_scope_param(url), ["openid", "email"])
 
     def test_google_store_tokens_requests_offline_access(self):
         url = Google(
@@ -1407,6 +1827,16 @@ class ScopeTest(unittest.TestCase):
         scopes = _scope_param(url)
         self.assertEqual(scopes[0], "read:user")
         self.assertIn("repo", scopes)
+
+    def test_github_derives_user_email_scope_from_email_claim(self):
+        # The email claims come from `GET /user/emails`, which needs
+        # the `user:email` scope.
+        url = GitHub(
+            client_id="id",
+            client_secret="s",
+            claims=["email", "email_verified"],
+        ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+        self.assertEqual(_scope_param(url), ["read:user", "user:email"])
 
     def test_extra_scopes_are_deduplicated(self):
         # Asking for the base scope again doesn't duplicate it.

--- a/tests/reboot/ping/frontend/web/test.py
+++ b/tests/reboot/ping/frontend/web/test.py
@@ -23,8 +23,8 @@ This is the smallest test that simultaneously exercises:
   feeds it to `setBearerToken`, and from there mutations carry the
   bearer in the proto field over the WebSocket multiplex.
 * The same `User` actor materializes the first time we touch it
-  (`_post_authenticate` auto-construct), even though no manual setup
-  call was made.
+  (the `_authenticated` hook auto-constructs it on token mint), even
+  though no manual setup call was made.
 """
 
 import asyncio

--- a/tests/reboot/ping/ping_test.py
+++ b/tests/reboot/ping/ping_test.py
@@ -220,6 +220,52 @@ class PingTest(unittest.IsolatedAsyncioTestCase):
                     # `make_bearer_token`.
                     self.assertEqual(data["user_id"], "test-user")
 
+    async def test_claims_transcribed_into_user_state(self):
+        """
+        Sign-in claims reach the `User` servicer: ping's `set_claims`
+        transcribes the `email` identity claim into state, `whoami`
+        surfaces it, and a later sign-in with a changed email keeps it
+        fresh — every sign-in delivers, so an A -> B -> A email change
+        ends at A.
+        """
+        await self.rbt.up(
+            Application(
+                servicers=[UserServicer, CounterServicer],
+            ),
+        )
+
+        user_id = "claims-user"
+        token = await self.rbt.make_valid_oauth_access_token(
+            user_id=user_id,
+            claims={"email": "first@example.com"},
+        )
+        context = self.rbt.create_external_context(
+            name=f"test-{self.id()}",
+            bearer_token=token,
+        )
+        response = await User.ref(user_id).whoami(context)
+        self.assertEqual(response.email, "first@example.com")
+
+        # Sign in again with a changed email; the delivery reaches
+        # `set_claims` again rather than being deduplicated away.
+        await self.rbt.make_valid_oauth_access_token(
+            user_id=user_id,
+            claims={"email": "second@example.com"},
+        )
+        response = await User.ref(user_id).whoami(context)
+        self.assertEqual(response.email, "second@example.com")
+
+        # A third sign-in going back to the first email converges on
+        # it: every sign-in delivers, so an A -> B -> A email change
+        # ends at A rather than being mistaken for a replay of the
+        # first delivery.
+        await self.rbt.make_valid_oauth_access_token(
+            user_id=user_id,
+            claims={"email": "first@example.com"},
+        )
+        response = await User.ref(user_id).whoami(context)
+        self.assertEqual(response.email, "first@example.com")
+
     async def test_ui_tool_ids_mapping(self):
         await self.rbt.up(
             Application(

--- a/tests/reboot/ping_api_rbt.golden.py
+++ b/tests/reboot/ping_api_rbt.golden.py
@@ -18043,8 +18043,9 @@ class UserSingletonServicer(UserBaseServicer):
         pass
 
     # For 'reboot.ping.UserMethods.SetClaims'.
-    # Concrete no-op default for `set_claims`. You may 
-    # override it in your Servicer to use the delivered claims.
+    # Default `set_claims` that raises when verified
+    # identity claims are delivered but your Servicer hasn't
+    # overridden it. Override it to consume the delivered claims.
     async def SetClaims(
         self,
         context: IMPORT_reboot_aio_contexts.TransactionContext,
@@ -18071,7 +18072,15 @@ class UserSingletonServicer(UserBaseServicer):
         This makes the method idempotent — re-delivering the same
         claims is harmless — which is required, since it runs on
         every sign-in, not just the first."""
-        pass
+        raise NotImplementedError(
+            "Verified identity claims were delivered for this "
+            "`User`, but its servicer does not "
+            "override `set_claims`, so the claims would "
+            "be discarded. Override `set_claims` to "
+            "derive `User` state from "
+            "`request.claims`, or stop requesting claims from your "
+            "identity provider."
+        )
 
 
     # For 'reboot.ping.UserMethods.CreateCounter'.
@@ -18345,8 +18354,9 @@ class UserServicer(UserBaseServicer):
         pass
 
     # For 'reboot.ping.UserMethods.SetClaims'.
-    # Concrete no-op default for `set_claims`. You may 
-    # override it in your Servicer to use the delivered claims.
+    # Default `set_claims` that raises when verified
+    # identity claims are delivered but your Servicer hasn't
+    # overridden it. Override it to consume the delivered claims.
     async def SetClaims(
         self,
         context: IMPORT_reboot_aio_contexts.TransactionContext,
@@ -18370,7 +18380,15 @@ class UserServicer(UserBaseServicer):
         This makes the method idempotent — re-delivering the same
         claims is harmless — which is required, since it runs on
         every sign-in, not just the first."""
-        pass
+        raise NotImplementedError(
+            "Verified identity claims were delivered for this "
+            "`User`, but its servicer does not "
+            "override `set_claims`, so the claims would "
+            "be discarded. Override `set_claims` to "
+            "derive `User` state from "
+            "`request.claims`, or stop requesting claims from your "
+            "identity provider."
+        )
 
 
     # For 'reboot.ping.UserMethods.CreateCounter'.

--- a/tests/reboot/ping_api_rbt.golden.py
+++ b/tests/reboot/ping_api_rbt.golden.py
@@ -523,6 +523,52 @@ def UserCreateRequestToProto(
     return google.protobuf.empty_pb2.Empty()
 
 
+def UserSetClaimsResponseToProto(
+    response: None
+) -> google.protobuf.empty_pb2.Empty:
+    assert response is None
+    return google.protobuf.empty_pb2.Empty()
+
+def UserSetClaimsResponseFromProto(
+    response: google.protobuf.empty_pb2.Empty
+) -> None:
+    assert isinstance(response, IMPORT_google_protobuf_empty_pb2_Empty)
+    return None
+
+def UserSetClaimsRequestToProto(
+    request: User.SetClaimsRequest
+) -> reboot.ping.ping_api_pb2.UserSetClaimsRequest:
+    assert isinstance(request, IMPORT_reboot_api.Model)
+    return IMPORT_reboot_api.pydantic_to_proto(
+        request,
+        User.SetClaimsRequest,
+        reboot.ping.ping_api_pb2.UserSetClaimsRequest,
+    )
+
+def UserSetClaimsRequestFromProto(
+    request: reboot.ping.ping_api_pb2.UserSetClaimsRequest
+) -> User.SetClaimsRequest:
+    assert isinstance(request, IMPORT_google_protobuf_message.Message)
+    return IMPORT_reboot_api.proto_to_pydantic(
+        request,
+        User.SetClaimsRequest
+    )
+
+def UserSetClaimsRequestFromInputFields(
+    claims: dict[str, IMPORT_typing.Any] | Unset,
+):
+    assert User.SetClaimsRequest is not None
+
+
+    __args__: dict[str, IMPORT_typing.Any] = {}
+
+    if not isinstance(claims, Unset):
+        __args__['claims'] = claims
+
+    return User.SetClaimsRequest(
+        **__args__,
+    )
+
 
 def CounterToProto(state: Counter.State, protobuf_state: reboot.ping.ping_api_pb2.Counter):
     assert isinstance(state, IMPORT_reboot_api.Model)
@@ -5081,6 +5127,7 @@ class UserServicerMiddleware(IMPORT_reboot_aio_internals_middleware.Middleware):
             'ListCounters': google.protobuf.empty_pb2.Empty,
             'Whoami': google.protobuf.empty_pb2.Empty,
             'Create': google.protobuf.empty_pb2.Empty,
+            'SetClaims': reboot.ping.ping_api_pb2.UserSetClaimsRequest,
         }
 
         # Get authorizer, if any, converting from a rule if necessary.
@@ -5321,6 +5368,24 @@ class UserServicerMiddleware(IMPORT_reboot_aio_internals_middleware.Middleware):
                     f"Method '{method}' is invalid"
             )
             yield  # Necessary for type checking.
+        elif method == 'SetClaims':
+            # Invariant here is that users should not have called this
+            # directly but only through code generated React
+            # components which should not have been generated except
+            # for valid method candidates.
+            logger.warning(
+                "Got a React query request with an invalid method name: "
+                f"Method '{method}' is invalid for servicer User."
+                "\n"
+                "Do you have a browser tab open for an older version "
+                "of this application, or for a different application all together?"
+            )
+            raise IMPORT_reboot.aio.aborted.SystemAborted(
+                IMPORT_rbt_v1alpha1.errors_pb2.InvalidMethod(),
+                message=
+                    f"Method '{method}' is invalid"
+            )
+            yield  # Necessary for type checking.
         else:
             logger.warning(
                 "Got a React query request with an invalid method name: "
@@ -5473,6 +5538,56 @@ class UserServicerMiddleware(IMPORT_reboot_aio_internals_middleware.Middleware):
                             status
                         ) from None
                     raise User.CreateAborted.from_grpc_aio_rpc_error(
+                        error
+                     ) from None
+
+        elif method == 'SetClaims':
+            request = reboot.ping.ping_api_pb2.UserSetClaimsRequest()
+            request.ParseFromString(request_bytes)
+
+            # NOTE: we automatically retry mutations that come through
+            # React when we get a `IMPORT_grpc.StatusCode.UNAVAILABLE` to
+            # match the retry logic we do in the React code generated
+            # to handle lack/loss of connectivity.
+            #
+            # TODO(benh): revisit this decision if we ever see reason
+            # to call `react_mutate()` from any place other than where
+            # we're executing React (e.g., browser, next.js server
+            # component, etc).
+            call_backoff = IMPORT_reboot_aio_backoff.Backoff()
+            while True:
+                # We make a full-fledged gRPC call, so that if this traffic
+                # was misrouted (i.e. this server is not authoritative
+                # for the state), it will now go to the right place. The
+                # receiving middleware will handle things like effect
+                # validation and so forth.
+                assert headers.application_id is not None  # Guaranteed by `Headers`.
+                stub = reboot.ping.ping_api_pb2_grpc.UserMethodsStub(
+                    self.channel_manager.get_channel_to(
+                        self.placement_client.address_for_actor(
+                            headers.application_id,
+                            headers.state_ref,
+                        )
+                    )
+                )
+                call = stub.SetClaims(
+                    request=request,
+                    metadata=headers.to_grpc_metadata(),
+                )
+                try:
+                    return await call
+                except IMPORT_grpc.aio.AioRpcError as error:
+                    if error.code() == IMPORT_grpc.StatusCode.UNAVAILABLE:
+                        await call_backoff()
+                        continue
+
+                    # Reconstitute the error that the server threw, if it was a declared error.
+                    status = await IMPORT_rpc_status_async.from_call(call)
+                    if status is not None:
+                        raise User.SetClaimsAborted.from_status(
+                            status
+                        ) from None
+                    raise User.SetClaimsAborted.from_grpc_aio_rpc_error(
                         error
                      ) from None
 
@@ -5789,6 +5904,83 @@ class UserServicerMiddleware(IMPORT_reboot_aio_internals_middleware.Middleware):
                     ),
                     state_type_name = IMPORT_reboot_aio_types.StateTypeName('reboot.ping.User'),
                     method='Create',
+                    context_type=IMPORT_reboot_aio_contexts.WorkflowContext,
+                    task=task,
+                    # Propagate state manager and state type so that
+                    # `until()` calls (via `WorkflowContext.retry_reactively_until()`)
+                    # can enter `reactively()` scoped to each `until()`
+                    # invocation.
+                    reactively_state_manager=self._state_manager,
+                    reactively_state_type=(
+                        self._servicer.__state_type__
+                    ),
+                )
+            )
+        elif 'SetClaims' == task.method_name:
+            if only_validate:
+                # TODO(benh): validate 'task.request' is correct type.
+                return (google.protobuf.empty_pb2.Empty(), None)
+
+            # Use an inline method to create a new scope, so that we can use
+            # variable names like `context` and `effects` in multiple branches
+            # in this code (notably when there are multiple task types) without
+            # hitting a mypy error that the variable's type is not consistent.
+            async def run_SetClaims(
+                context: IMPORT_reboot_aio_contexts.WorkflowContext,
+                *,
+                validating_effects: bool = False,
+            ):
+                async with self._state_manager.task_workflow(
+                    context,
+                    task,
+                    on_loop_iteration=on_loop_iteration,
+                    validating_effects=validating_effects,
+                ) as complete:
+                    try:
+                        response = await (UserWorkflowStub(
+                            context=context,
+                            state_ref=context._state_ref,
+                        ).SetClaims(
+                            UserSetClaimsRequestFromProto(IMPORT_typing.cast(reboot.ping.ping_api_pb2.UserSetClaimsRequest, task.request)),
+                            bearer_token=__internal_magic_token__,
+                            idempotency=IMPORT_reboot_aio_idempotency.Idempotency(
+                                alias=f'Task {IMPORT_uuid.UUID(bytes=task.task_id.task_uuid)}',
+                            ),
+                        ))
+                        await complete(task, (response, None))
+                        return (response, None)
+                    except IMPORT_asyncio.CancelledError:
+                        # Do not retry a task if it was cancelled by a caller.
+                        if self.tasks_dispatcher.is_task_cancelled(task.task_id.task_uuid):
+                            result = (
+                                None,
+                                IMPORT_reboot.aio.aborted.SystemAborted(
+                                    IMPORT_rbt_v1alpha1.errors_pb2.Cancelled(),
+                                ).to_status(),
+                            )
+                            await complete(task, result)
+                            return result
+                        else:
+                            raise
+                    except IMPORT_reboot.aio.aborted.Aborted as aborted:
+                        error_type = f'{aborted._protobuf_error.__class__.__module__}.{aborted._protobuf_error.__class__.__qualname__}'
+                        # Do not retry a task if the error was specified in the
+                        # proto file.
+                        if error_type in self._specified_errors_by_service_method_name.get('reboot.ping.UserMethods.SetClaims', []):
+                            result = (None, aborted.to_status())
+                            await complete(task, result)
+                            return result
+                        raise
+
+
+            return await run_SetClaims(
+                self.create_context(
+                    headers=IMPORT_reboot_aio_headers.Headers(
+                        application_id=self.application_id,
+                        state_ref=IMPORT_reboot_aio_types.StateRef(task.task_id.state_ref),
+                    ),
+                    state_type_name = IMPORT_reboot_aio_types.StateTypeName('reboot.ping.User'),
+                    method='SetClaims',
                     context_type=IMPORT_reboot_aio_contexts.WorkflowContext,
                     task=task,
                     # Propagate state manager and state type so that
@@ -7773,6 +7965,512 @@ class UserServicerMiddleware(IMPORT_reboot_aio_internals_middleware.Middleware):
         with IMPORT_reboot_aio_tracing.context_from_headers(headers):
             return await _run()
 
+    async def __SetClaims(
+        self,
+        context: IMPORT_reboot_aio_contexts.TransactionContext,
+        state: reboot.ping.ping_api_pb2.User,
+        request: reboot.ping.ping_api_pb2.UserSetClaimsRequest,
+        *,
+        validating_effects: bool,
+    ) -> google.protobuf.empty_pb2.Empty:
+        try:
+            typed_state: User.State = UserFromProto(state, is_initial_state=(context.state_id in states_being_constructed))
+
+            # TODO: assert that there are no ongoing transactions for this state.
+            #
+            # The `typed_state` should be already validated above, so we can
+            # just store it here.
+            ongoing_transaction_states[ongoing_transaction_state_key(context)] = typed_state
+            response = (
+                await self._servicer._SetClaims(
+                    context=context,
+                    state=typed_state,
+                    request=request
+                )
+            )
+
+
+            UserToProto(typed_state, state)
+
+            IMPORT_reboot_aio_types.assert_type(
+                response,
+                [google.protobuf.empty_pb2.Empty],
+            )
+            self.maybe_raise_effect_validation_retry(
+                logger=logger,
+                idempotency_manager=context,
+                method_name='User.SetClaims',
+                validating_effects=validating_effects,
+                context=context,
+            )
+            return response
+        except IMPORT_reboot_aio_contexts.EffectValidationRetry:
+            # Doing effect validation, just let this propagate.
+            raise
+        except IMPORT_reboot.aio.aborted.Aborted as aborted:
+            # If the caller aborted due to a retryable error, just
+            # propagate the aborted instead of propagating `Unknown`
+            # so that a client can transparently retry.
+            if IMPORT_reboot.aio.aborted.is_retryable(aborted):
+                raise aborted
+            # Log any _unhandled_ abort stack traces to make it
+            # easier for debugging.
+            #
+            # NOTE: we don't log if we're a task as it will be logged
+            # in `public/reboot/aio/internals/tasks_dispatcher.py` instead.
+            aborted_type: IMPORT_typing.Optional[type] = None
+            aborted_type = User.SetClaimsAborted
+            if isinstance(aborted, IMPORT_reboot.aio.aborted.SystemAborted):
+                # Not logging when within `node` as we already log there.
+                if IMPORT_reboot_nodejs_python.should_print_stacktrace():
+                    logger.warning(
+                        f"Unhandled (in 'reboot.ping.User.SetClaims') {aborted}; propagating as 'Unknown'\n" +
+                        ''.join(IMPORT_traceback.format_exception(aborted))
+                    )
+                raise IMPORT_reboot.aio.aborted.SystemAborted(
+                    IMPORT_rbt_v1alpha1.errors_pb2.Unknown(),
+                    # TODO(benh): consider whether or not we want to
+                    # include the 'package.service.method' which may
+                    # get concatenated together forming a kind of
+                    # "stack trace"; while it's super helpful for
+                    # debugging, it does expose implementation
+                    # information.
+                    message=f"unhandled (in 'reboot.ping.User.SetClaims') {aborted}"
+                )
+            else:
+                if (
+                    aborted_type is not None and
+                    not isinstance(aborted, aborted_type) and
+                    aborted_type.is_declared_error(aborted.error)
+                ):
+                    # We propagate declared errors that might have
+                    # come from another call, i.e., we might have an
+                    # `Aborted` but not for this method but the
+                    # `Aborted` that we have has an error that this
+                    # method declared. This allows a developer to
+                    # simply add the declared error to their `.proto`
+                    # file rather than having to catch and re-raise
+                    # the error with their own aborted type.
+                    if context.task is None:
+                        logger.warning(
+                            f"Propagating unhandled but declared error (in 'reboot.ping.User.SetClaims') {aborted}"
+                        )
+                elif (
+                    aborted_type is None or
+                    not isinstance(aborted, aborted_type)
+                ):
+                    # Not logging when within `node` as we already log there.
+                    if IMPORT_reboot_nodejs_python.should_print_stacktrace():
+                        logger.warning(
+                            f"Unhandled (in 'reboot.ping.User.SetClaims') {aborted}; propagating as 'Unknown'\n" +
+                            ''.join(IMPORT_traceback.format_exception(aborted))
+                        )
+                    # If this wasn't a declared error than we
+                    # propagate it as `Unknown`.
+                    raise IMPORT_reboot.aio.aborted.SystemAborted(
+                        IMPORT_rbt_v1alpha1.errors_pb2.Unknown(),
+                        # TODO(benh): consider whether or not we want to
+                        # include the 'package.service.method' which may
+                        # get concatenated together forming a kind of
+                        # "stack trace"; while it's super helpful for
+                        # debugging, it does expose implementation
+                        # information.
+                        message=f"unhandled (in 'reboot.ping.User.SetClaims') {aborted}"
+                    )
+
+            raise
+        except IMPORT_asyncio.CancelledError:
+            # It's pretty normal for an RPC to be cancelled; it's not useful to
+            # print a stack trace.
+            raise
+        except IMPORT_google_protobuf_message.DecodeError as decode_error:
+            # We usually see this error when we are trying to construct a proto
+            # message which is too deeply nested: protobuf has a limit of 100
+            # nested messages. See the limits here:
+            #   https://protobuf.dev/programming-guides/proto-limits/
+
+            if IMPORT_reboot_nodejs_python.should_print_stacktrace():
+                logger.warning(
+                    "Unhandled (in 'reboot.ping.User.SetClaims') "
+                    f"{type(decode_error).__name__}{': ' + str(decode_error) if len(str(decode_error)) > 0 else ''}; "
+                    "This is usually caused by a deeply nested protobuf message, which is not supported by protobuf.\n"
+                    "See the limits here: https://protobuf.dev/programming-guides/proto-limits/" +
+                    ''.join(IMPORT_traceback.format_exception(decode_error))
+                )
+            raise IMPORT_reboot.aio.aborted.SystemAborted(
+                IMPORT_rbt_v1alpha1.errors_pb2.Unknown(),
+                message=f"unhandled (in 'reboot.ping.User.SetClaims') {decode_error}; "
+                        "This is usually caused by a deeply nested protobuf message, which is not supported by protobuf.\n"
+                        "See the limits here: https://protobuf.dev/programming-guides/proto-limits/"
+            )
+        except BaseException as exception:
+            # Not logging when within `node` as we already log there.
+            if IMPORT_reboot_nodejs_python.should_print_stacktrace():
+                logger.warning(
+                    "Unhandled (in 'reboot.ping.User.SetClaims') "
+                    f"{type(exception).__name__}{': ' + str(exception) if len(str(exception)) > 0 else ''}; "
+                    "propagating as 'Unknown'\n" +
+                    ''.join(IMPORT_traceback.format_exception(exception))
+                )
+            raise IMPORT_reboot.aio.aborted.SystemAborted(
+                IMPORT_rbt_v1alpha1.errors_pb2.Unknown(),
+                # TODO(benh): consider whether or not we want to
+                # include the 'package.service.method' which may
+                # get concatenated together forming a kind of
+                # "stack trace"; while it's super helpful for
+                # debugging, it does expose implementation
+                # information.
+                message=f"unhandled (in 'reboot.ping.User.SetClaims') {type(exception).__name__}: {exception}"
+            )
+        finally:
+            if ongoing_transaction_state_key(context) in ongoing_transaction_states:
+                del ongoing_transaction_states[ongoing_transaction_state_key(context)]
+
+    @IMPORT_reboot_aio_tracing.function_span(
+        # We expect an `EffectValidationRetry` exception; that's not an error.
+        set_status_on_exception=False
+    )
+    async def _SetClaims(
+        self,
+        request: reboot.ping.ping_api_pb2.UserSetClaimsRequest,
+        context: IMPORT_reboot_aio_contexts.TransactionContext,
+        *,
+        validating_effects: bool,
+        grpc_context: IMPORT_typing.Optional[IMPORT_grpc.aio.ServicerContext] = None,
+    ) -> google.protobuf.empty_pb2.Empty:
+        # Try to verify the token if a token verifier exists.
+        context.auth = await self._maybe_verify_token(
+            headers=context._headers, method='SetClaims'
+        )
+
+        # Try and "preload" to opportunistically load both state and
+        # idempotent mutations from the database in a single
+        # round-trip. This is fire-and-forget; subsequent calls to
+        # `_load()` and `check_for_idempotent_mutation()` should find
+        # the preloaded data and skip their own calls to the database.
+        #
+        # TODO: a tradeoff we're making here is that we load
+        # idempotent mutations even if this is just a reader and we
+        # don't need them. Consider only preloading for writers and
+        # transactions if loading idempotent mutations is
+        # unnecessarily slow (and we haven't optimized that via a
+        # database stored bloom filter).
+        #
+        # We do this _after_ verifying the token so it is not a
+        # denial-of-service attack vector, i.e., only callers with
+        # valid tokens may trigger preloads on the database.
+        self._state_manager.preload(
+            context.state_type_name,
+            context._state_ref,
+        )
+
+        # Check if we already have performed this mutation!
+        #
+        # We do this _before_ calling 'transactionally()' because
+        # if this call is for a transaction method _and_ we've
+        # already performed the transaction then we don't want to
+        # become a transaction participant (again) we just want to
+        # return the transaction's response.
+        idempotent_mutation = await self._state_manager.check_for_idempotent_mutation(
+            context
+        )
+
+        if idempotent_mutation is not None:
+            response = google.protobuf.empty_pb2.Empty()
+            response.ParseFromString(idempotent_mutation.response)
+            return response
+
+        async with self._state_manager.transactionally(
+            context,
+            self.tasks_dispatcher,
+            aborted_type=User.SetClaimsAborted,
+        ) as transaction:
+            assert transaction is not None
+            async with self._state_manager.transaction(
+                context,
+                self._servicer.__state_type__,
+                transaction,
+                authorize=self._maybe_authorize(
+                    method_name='reboot.ping.UserMethods.SetClaims',
+                    headers=context._headers,
+                    auth=context.auth,
+                    request=request,
+                ),
+                from_constructor=False,
+                requires_constructor=True
+            ) as (state, complete):
+
+                response = await self.__SetClaims(
+                    context,
+                    state,
+                    request,
+                    validating_effects=validating_effects,
+                )
+
+                await complete(
+                    IMPORT_reboot_aio_state_managers.Effects(
+                        state=state,
+                        response=response,
+                    )
+                )
+                return response
+
+    async def _schedule_SetClaims(
+        self,
+        *,
+        request: reboot.ping.ping_api_pb2.UserSetClaimsRequest,
+        headers: IMPORT_reboot_aio_headers.Headers,
+        grpc_context: IMPORT_grpc.aio.ServicerContext,
+    ) -> tuple[IMPORT_reboot_aio_contexts.WriterContext, google.protobuf.empty_pb2.Empty]:
+        context: IMPORT_reboot_aio_contexts.WriterContext = self.create_context(
+            headers=headers,
+            state_type_name = IMPORT_reboot_aio_types.StateTypeName('reboot.ping.User'),
+            method='SetClaims',
+            context_type=IMPORT_reboot_aio_contexts.WriterContext,
+        )
+        response = google.protobuf.empty_pb2.Empty()
+
+        # Try to verify the token if a token verifier exists.
+        context.auth = await self._maybe_verify_token(
+            headers=headers, method='SetClaims'
+        )
+
+        # Try and "preload" to opportunistically load both state and
+        # idempotent mutations from the database in a single
+        # round-trip. This is fire-and-forget; subsequent calls to
+        # `_load()` and `check_for_idempotent_mutation()` should find
+        # the preloaded data and skip their own calls to the database.
+        #
+        # TODO: a tradeoff we're making here is that we load
+        # idempotent mutations even if this is just a reader and we
+        # don't need them. Consider only preloading for writers and
+        # transactions if loading idempotent mutations is
+        # unnecessarily slow (and we haven't optimized that via a
+        # database stored bloom filter).
+        #
+        # We do this _after_ verifying the token so it is not a
+        # denial-of-service attack vector, i.e., only callers with
+        # valid tokens may trigger preloads on the database.
+        self._state_manager.preload(
+            context.state_type_name,
+            context._state_ref,
+        )
+
+        # Check if we already have performed this schedule! Note that
+        # we need to do this for all kinds of methods because this is
+        # effectively a mutation (actually a `writer`, see below).
+        #
+        # We do this _before_ calling 'transactionally()' because
+        # if this call is for a transaction method _and_ we've
+        # already performed the transaction then we don't want to
+        # become a transaction participant (again) we just want to
+        # return the transaction's response.
+        idempotent_mutation = await self._state_manager.check_for_idempotent_mutation(
+            context
+        )
+
+        if idempotent_mutation is not None:
+            response.ParseFromString(idempotent_mutation.response)
+
+            # We should have only scheduled a single task!
+            assert len(idempotent_mutation.task_ids) == 1
+            assert grpc_context is not None
+            grpc_context.set_trailing_metadata(
+                grpc_context.trailing_metadata() +
+                (
+                    (
+                        IMPORT_reboot_aio_headers.TASK_ID_UUID,
+                        str(IMPORT_uuid.UUID(bytes=idempotent_mutation.task_ids[0].task_uuid))
+                    ),
+                )
+            )
+
+            return context, response
+
+        async with self._state_manager.transactionally(
+            context,
+            self.tasks_dispatcher,
+            aborted_type=User.SetClaimsAborted,
+        ) as transaction:
+
+            async with self._state_manager.writer(
+                context,
+                self._servicer.__state_type__,
+                self.tasks_dispatcher,
+                transaction=transaction,
+                authorize=self._maybe_authorize(
+                    method_name='reboot.ping.UserMethods.SetClaims',
+                    headers=context._headers,
+                    auth=context.auth,
+                    request=request,
+                ),
+                from_constructor=False,
+                requires_constructor=True
+            ) as (state, writer):
+
+                task = await UserServicerTasks(
+                    context=context,
+                    state_ref=context._state_ref,
+                ).SetClaims(
+                    UserSetClaimsRequestFromProto(request),
+                    schedule=context._headers.task_schedule,
+                )
+
+                effects = IMPORT_reboot_aio_state_managers.Effects(
+                    response=response,
+                    state=state,
+                    tasks=[task],
+                )
+
+                assert effects.tasks is not None
+
+                await writer.complete(effects)
+
+                assert grpc_context is not None
+
+                grpc_context.set_trailing_metadata(
+                    grpc_context.trailing_metadata() +
+                    (
+                        (
+                            IMPORT_reboot_aio_headers.TASK_ID_UUID,
+                            str(IMPORT_uuid.UUID(bytes=task.task_id.task_uuid))
+                        ),
+                    )
+                )
+
+                return context, response
+
+        return context, response
+
+
+    # Entrypoint for non-reactive network calls (i.e. typical gRPC calls).
+    async def SetClaims(
+        self,
+        request: reboot.ping.ping_api_pb2.UserSetClaimsRequest,
+        grpc_context: IMPORT_grpc.aio.ServicerContext,
+    ) -> google.protobuf.empty_pb2.Empty:
+        headers = IMPORT_reboot_aio_headers.Headers.from_grpc_context(grpc_context)
+        assert headers.application_id is not None  # Guaranteed by `Headers`.
+
+        # Confirm whether this is the right server to be serving this
+        # request.
+        try:
+            authoritative_server = self.placement_client.server_for_actor(
+                headers.application_id,
+                headers.state_ref,
+            )
+        except IMPORT_reboot_aio_placement.UnknownApplicationError:
+            # It's possible that the user did indeed type an application ID
+            # that doesn't exist, but it's also quite possible that this
+            # request reached us before the placement planner had gossipped
+            # out the information about which applications exist (we see
+            # this e.g. after `rbt dev`'s chaos monkey restarts). For that
+            # reason, abort with a retryable error.
+            await grpc_context.abort(
+                IMPORT_grpc.StatusCode.UNAVAILABLE,
+                f"Application '{headers.application_id}' not found. If you "
+                "are confident the application exists, this may be because "
+                "the system is still starting.",
+            )
+            raise  # Unreachable but necessary for mypy.
+        if authoritative_server != self.server_id:
+            # This is NOT the correct server. Fail.
+            await grpc_context.abort(
+                IMPORT_grpc.StatusCode.UNAVAILABLE,
+                f"Server '{self.server_id}' is not authoritative for this "
+                f"request; server '{authoritative_server}' is.",
+            )
+            raise  # Unreachable but necessary for mypy.
+
+        @IMPORT_reboot_aio_internals_middleware.maybe_run_function_twice_to_validate_effects
+        async def _run(
+            validating_effects: bool,
+        ) -> google.protobuf.empty_pb2.Empty:
+            context: IMPORT_typing.Optional[IMPORT_reboot_aio_contexts.Context] = None
+            try:
+                if headers.task_schedule is not None:
+                    context, response = await self._schedule_SetClaims(
+                        headers=headers,
+                        request=request,
+                        grpc_context=grpc_context,
+                    )
+                    return response
+
+                context = self.create_context(
+                    headers=headers,
+                    state_type_name = IMPORT_reboot_aio_types.StateTypeName('reboot.ping.User'),
+                    method='SetClaims',
+                    context_type=IMPORT_reboot_aio_contexts.TransactionContext,
+                )
+                assert context is not None
+
+                return await self._SetClaims(
+                    request,
+                    context,
+                    validating_effects=validating_effects,
+                    grpc_context=grpc_context,
+                )
+            except IMPORT_reboot_aio_contexts.EffectValidationRetry:
+                # Doing effect validation, just let this propagate.
+                raise
+            except IMPORT_reboot.aio.aborted.Aborted as aborted:
+                status = IMPORT_rpc_status_sync.to_status(aborted.to_status())
+                # Need to add transaction participants here because
+                # calling `grpc_context.abort_with_status()` will
+                # ignore any other trailing metadata. Only propagate
+                # transaction participants metadata if the caller cares.
+                # Callers that care are those that are themselves transactions.
+                # It's important to not just send this information to everyone;
+                # some clients can't tolerate trailers, see:
+                #   https://github.com/reboot-dev/mono/issues/5081
+                if context is not None and headers.transaction_ids is not None:
+                    assert context.transaction_id is not None
+                    status = status._replace(
+                        trailing_metadata=status.trailing_metadata + context.participants.to_grpc_metadata(
+                            read_only_aware=headers.coordinator_read_only_aware,
+                        )
+                    )
+                await grpc_context.abort_with_status(status)
+                raise  # Unreachable but necessary for mypy.
+            except IMPORT_asyncio.CancelledError:
+                # It's pretty normal for an RPC to be cancelled; it's not useful to
+                # print a stack trace.
+                raise
+            except BaseException as exception:
+                # Print the exception stack trace for easier debugging. Note
+                # that we don't include the stack trace in an error message
+                # for the same reason that gRPC doesn't do so by default,
+                # see https://github.com/grpc/grpc/issues/14897, but since this
+                # should only get logged on the server side it is safe.
+                logger.warning(
+                    'Unhandled exception\n' +
+                    ''.join(IMPORT_traceback.format_exc() if IMPORT_reboot_nodejs_python.should_print_stacktrace() else [f"{type(exception).__name__}: {exception}"])
+                )
+
+                # Re-raise the exception for gRPC to handle!
+                #
+                # TODO: gRPC will print a stack trace from this
+                # exception which we don't want if we're executing via
+                # Node.js.
+                raise
+            finally:
+                # Propagate transaction participants, if the caller cares.
+                # Callers that care are those that are themselves transactions.
+                # It's important to not just send this information to everyone;
+                # some clients can't tolerate trailers, see:
+                #   https://github.com/reboot-dev/mono/issues/5081
+                if context is not None and headers.transaction_ids is not None:
+                    assert context.transaction_id is not None
+                    grpc_context.set_trailing_metadata(
+                        grpc_context.trailing_metadata() +
+                        context.participants.to_grpc_metadata(
+                            read_only_aware=headers.coordinator_read_only_aware,
+                        )
+                    )
+
+        with IMPORT_reboot_aio_tracing.context_from_headers(headers):
+            return await _run()
+
     def _maybe_authorize(
         self,
         *,
@@ -7805,6 +8503,27 @@ class UserServicerMiddleware(IMPORT_reboot_aio_internals_middleware.Middleware):
                 context_type=IMPORT_reboot_aio_contexts.ReaderContext,
             ) as context:
                 context.auth = auth
+
+                # The framework's `set_claims` method should only ever
+                # be app-internal only; even the owning user shouldn't
+                # be trusted to call it, since the identity provider's
+                # claims may deliver info like "validated email address"
+                # and other things we don't trust the user to set
+                # directly.
+                #
+                # This extra app-internal check comes before any
+                # authorizer, so no authorizer — including a blanket
+                # `allow()` — can expose the method to external callers.
+                if (
+                    method_name.split('.')[-1] == 'SetClaims'
+                    and not context.app_internal
+                ):
+                    raise IMPORT_reboot.aio.aborted.SystemAborted(
+                        IMPORT_rbt_v1alpha1.errors_pb2.PermissionDenied(),
+                        message=
+                        f"You are not authorized to call '{method_name}' on "
+                        f"`reboot.ping.User('{headers.state_ref.id}')`"
+                    )
 
                 # Get the authorizer decision.
                 authorization_decision = await self._authorizer.authorize(
@@ -12176,6 +12895,7 @@ class UserReaderStub(_UserStub):
 
 
 
+
 class UserWriterStub(_UserStub):
 
     def __init__(
@@ -12239,6 +12959,7 @@ class UserWriterStub(_UserStub):
         ) as call:
             assert isinstance(call, IMPORT_typing.Awaitable), type(call)
             return await call
+
 
 
 
@@ -12380,6 +13101,49 @@ class UserWorkflowStub(_UserStub):
                 reader=False,
                 response_type=google.protobuf.empty_pb2.Empty,
                 aborted_type=User.CreateAborted,
+                metadata=metadata,
+                idempotency_key=idempotency_key,
+                per_iteration=idempotency.per_iteration if idempotency is not None else False,
+                always=idempotency.always if idempotency is not None else False,
+                bearer_token=bearer_token,
+            ) as call:
+                assert isinstance(call, IMPORT_typing.Awaitable), type(call)
+                return await call
+
+    async def SetClaims(
+        self,
+        request: User.SetClaimsRequest,
+        idempotency: IMPORT_typing.Optional[IMPORT_reboot_aio_idempotency.Idempotency] = None,
+        *,
+        metadata: IMPORT_typing.Optional[IMPORT_reboot_aio_types.GrpcMetadata] = None,
+        bearer_token: IMPORT_typing.Optional[str] = None,
+    ) -> google.protobuf.empty_pb2.Empty:
+        idempotency_key: IMPORT_typing.Optional[IMPORT_uuid.UUID]
+        proto_request = UserSetClaimsRequestToProto(
+            request,
+        )
+
+        with self._idempotency_manager.idempotently(
+            state_type_name=IMPORT_reboot_aio_types.StateTypeName('reboot.ping.User'),
+            state_ref=self._headers.state_ref,
+            service_name=IMPORT_reboot_aio_types.ServiceName('reboot.ping.UserMethods'),
+            method='SetClaims',
+            mutation=True,
+            request=proto_request,
+            metadata=metadata,
+            idempotency=idempotency,
+            aborted_type=User.SetClaimsAborted,
+        ) as idempotency_key:
+            async with self._call(
+                IMPORT_reboot_aio_types.StateTypeName('reboot.ping.User'),
+                IMPORT_reboot_aio_types.ServiceName('reboot.ping.UserMethods'),
+                'SetClaims',
+                self._reboot_ping_usermethods_stub.SetClaims,
+                proto_request,
+                unary=True,
+                reader=False,
+                response_type=google.protobuf.empty_pb2.Empty,
+                aborted_type=User.SetClaimsAborted,
                 metadata=metadata,
                 idempotency_key=idempotency_key,
                 per_iteration=idempotency.per_iteration if idempotency is not None else False,
@@ -12563,6 +13327,59 @@ class UserTasksStub(_UserStub):
                     IMPORT_rbt_v1alpha1.errors_pb2.Internal(),
                     message='Trailing metadata missing for task schedule',
                 )
+    async def SetClaims(
+        self,
+        request: User.SetClaimsRequest,
+        idempotency: IMPORT_typing.Optional[IMPORT_reboot_aio_idempotency.Idempotency] = None,
+        *,
+        metadata: IMPORT_typing.Optional[IMPORT_reboot_aio_types.GrpcMetadata] = None,
+        bearer_token: IMPORT_typing.Optional[str] = None,
+    ) -> IMPORT_rbt_v1alpha1.tasks_pb2.TaskId:
+        idempotency_key: IMPORT_typing.Optional[IMPORT_uuid.UUID]
+        proto_request = UserSetClaimsRequestToProto(
+            request,
+        )
+
+        with self._idempotency_manager.idempotently(
+            state_type_name=IMPORT_reboot_aio_types.StateTypeName('reboot.ping.User'),
+            state_ref=self._headers.state_ref,
+            service_name=IMPORT_reboot_aio_types.ServiceName('reboot.ping.UserMethods'),
+            method='SetClaims',
+            mutation=True,
+            request=proto_request,
+            metadata=metadata,
+            idempotency=idempotency,
+            aborted_type=User.SetClaimsAborted,
+        ) as idempotency_key:
+            async with self._call(
+                IMPORT_reboot_aio_types.StateTypeName('reboot.ping.User'),
+                IMPORT_reboot_aio_types.ServiceName('reboot.ping.UserMethods'),
+                'SetClaims',
+                self._reboot_ping_usermethods_stub.SetClaims,
+                proto_request,
+                unary=True,
+                reader=False,
+                response_type=google.protobuf.empty_pb2.Empty,
+                aborted_type=User.SetClaimsAborted,
+                metadata=metadata,
+                idempotency_key=idempotency_key,
+                per_iteration=idempotency.per_iteration if idempotency is not None else False,
+                always=idempotency.always if idempotency is not None else False,
+                bearer_token=bearer_token,
+            ) as call:
+                assert isinstance(call, IMPORT_typing.Awaitable), type(call)
+                await call
+                for (key, value) in await call.trailing_metadata():  # type: ignore[misc, attr-defined]
+                    if key == IMPORT_reboot_aio_headers.TASK_ID_UUID:
+                        return IMPORT_rbt_v1alpha1.tasks_pb2.TaskId(
+                            state_type=IMPORT_reboot_aio_types.StateTypeName('reboot.ping.User'),
+                            state_ref=self._headers.state_ref.to_str(),
+                            task_uuid=IMPORT_uuid.UUID(value).bytes,
+                        )
+                raise IMPORT_reboot.aio.aborted.SystemAborted(
+                    IMPORT_rbt_v1alpha1.errors_pb2.Internal(),
+                    message='Trailing metadata missing for task schedule',
+                )
 
 
 class UserServicerTasks:
@@ -12657,6 +13474,29 @@ class UserServicerTasks:
             state_ref=self._state_ref,
             method_name='Create',
             request=UserCreateRequestToProto(
+            ),
+            schedule=(IMPORT_reboot_time_DateTimeWithTimeZone.now() + schedule) if isinstance(
+                schedule, IMPORT_datetime_timedelta
+            ) else schedule,
+        )
+
+        self._context._tasks.append(task)
+
+        return task
+
+    async def SetClaims(
+        self,
+        request: User.SetClaimsRequest,
+        *,
+        schedule: IMPORT_typing.Optional[IMPORT_datetime_datetime | IMPORT_datetime_timedelta] = None,
+    ) -> IMPORT_reboot_aio_tasks.TaskEffect:
+        schedule = ensure_has_timezone(when=schedule)
+        task = IMPORT_reboot_aio_tasks.TaskEffect(
+            state_type=IMPORT_reboot_aio_types.StateTypeName('reboot.ping.User'),
+            state_ref=self._state_ref,
+            method_name='SetClaims',
+            request=UserSetClaimsRequestToProto(
+                request,
             ),
             schedule=(IMPORT_reboot_time_DateTimeWithTimeZone.now() + schedule) if isinstance(
                 schedule, IMPORT_datetime_timedelta
@@ -13761,7 +14601,8 @@ class PongAuthorizer(
 UserStateType: IMPORT_typing.TypeAlias = reboot.ping.ping_api_pb2.User
 UserRequestTypes: IMPORT_typing.TypeAlias = \
         reboot.ping.ping_api_pb2.UserCreateCounterRequest \
-        | google.protobuf.empty_pb2.Empty
+        | google.protobuf.empty_pb2.Empty \
+        | reboot.ping.ping_api_pb2.UserSetClaimsRequest
 
 class UserAuthorizer(
     IMPORT_reboot_aio_auth_authorizers.Authorizer[UserStateType, UserRequestTypes],
@@ -13821,6 +14662,18 @@ class UserAuthorizer(
               None
             ]
         ] = None,
+        SetClaims: IMPORT_typing.Optional[
+            IMPORT_reboot_aio_auth_authorizers.AuthorizerRule[
+              User.State,
+              User.SetClaimsRequest,
+            ]
+        ] = None,
+        set_claims: IMPORT_typing.Optional[
+            IMPORT_reboot_aio_auth_authorizers.AuthorizerRule[
+              User.State,
+              User.SetClaimsRequest,
+            ]
+        ] = None,
         # NOTE: using `_` prefix for `_default` so as not to collide
         # with any method names since a prefixed `_` is forbidden by
         # our protoc plugins.
@@ -13854,6 +14707,11 @@ class UserAuthorizer(
                 f"Cannot specify both 'Create' and 'create' authorizer rules"
             )
         self._create = create or Create
+        if set_claims is not None and SetClaims is not None:
+            raise ValueError(
+                f"Cannot specify both 'SetClaims' and 'set_claims' authorizer rules"
+            )
+        self._set_claims = set_claims or SetClaims
         self.__default = _default
 
     async def authorize(
@@ -13884,6 +14742,12 @@ class UserAuthorizer(
         elif method_name == 'reboot.ping.UserMethods.Create':
             return await self.Create(
                 context=context,
+            )
+        elif method_name == 'reboot.ping.UserMethods.SetClaims':
+            return await self.SetClaims(
+                context=context,
+                state=UserFromProto(state, is_initial_state=(context.state_id in states_being_constructed)) if state is not None else state,
+                request=UserSetClaimsRequestFromProto(request) if request is not None else request,
             )
         else:
             return IMPORT_rbt_v1alpha1.errors_pb2.PermissionDenied()
@@ -13947,6 +14811,20 @@ class UserAuthorizer(
             # in the Pydantic API. We need to support dropping 'request'
             # argument in the default 'AuthorizerRule's before.
             request=None,
+        )
+
+    # For 'reboot.ping.UserMethods.SetClaims'.
+    async def SetClaims(
+        self,
+        *,
+        context: IMPORT_reboot_aio_contexts.ReaderContext,
+        state: User.State,
+        request: User.SetClaimsRequest,
+    ) -> IMPORT_reboot_aio_auth_authorizers.Authorizer.Decision:
+        return await (self._set_claims or self.__default).execute(
+            context=context,
+            state=state,
+            request=request,
         )
 
 
@@ -16518,6 +17396,7 @@ class UserBaseServicer(IMPORT_reboot_aio_servicers.Servicer):
 
 
 
+
     InlineWriterCallableResult = IMPORT_typing.TypeVar('InlineWriterCallableResult', covariant=True)
 
     class InlineWriterCallable(IMPORT_typing.Protocol[InlineWriterCallableResult]):
@@ -17001,6 +17880,16 @@ class UserBaseServicer(IMPORT_reboot_aio_servicers.Servicer):
     ) -> google.protobuf.empty_pb2.Empty:
         raise NotImplementedError
 
+    # For 'reboot.ping.UserMethods.SetClaims'.
+    @IMPORT_abc_abstractmethod
+    async def _SetClaims(
+        self,
+        context: IMPORT_reboot_aio_contexts.TransactionContext,
+        state: User.State,
+        request: reboot.ping.ping_api_pb2.UserSetClaimsRequest,
+    ) -> google.protobuf.empty_pb2.Empty:
+        raise NotImplementedError
+
 
 
 class UserSingletonServicer(UserBaseServicer):
@@ -17118,13 +18007,47 @@ class UserSingletonServicer(UserBaseServicer):
         context: IMPORT_reboot_aio_contexts.TransactionContext,
         state: User.State,
     ) -> None:
-        pass
+        return await self.create(
+            context,
+            state,
+        )
 
     async def create(
         self,
         context: IMPORT_reboot_aio_contexts.TransactionContext,
         state: reboot.ping.ping_api_pb2.User,
     ) -> None:
+        pass
+
+    # For 'reboot.ping.UserMethods.SetClaims'.
+    # Concrete no-op default for `set_claims`. You may 
+    # override it in your Servicer to use the delivered claims.
+    async def SetClaims(
+        self,
+        context: IMPORT_reboot_aio_contexts.TransactionContext,
+        state: User.State,
+        request: User.SetClaimsRequest,
+    ) -> None:
+        return await self.set_claims(
+            context,
+            state,
+            request,
+        )
+
+    async def set_claims(
+        self,
+        context: IMPORT_reboot_aio_contexts.TransactionContext,
+        state: reboot.ping.ping_api_pb2.User,
+        request: User.SetClaimsRequest,
+    ) -> None:
+        """The framework calls this on every sign-in to deliver the
+        user's verified identity claims. `request.claims` is the
+        complete, current set of verified claims (a `dict[str, Any]`
+        keyed by claim name); treat it as a full replace and fully
+        derive any claim-backed User state from it.
+        This makes the method idempotent — re-delivering the same
+        claims is harmless — which is required, since it runs on
+        every sign-in, not just the first."""
         pass
 
 
@@ -17218,6 +18141,31 @@ class UserSingletonServicer(UserBaseServicer):
                 await self.Create(
                     context,
                     state,
+                )
+            )
+
+
+    # For 'reboot.ping.UserMethods.SetClaims'.
+    async def _SetClaims(
+        self,
+        context: IMPORT_reboot_aio_contexts.TransactionContext,
+        state: User.State,
+        request: reboot.ping.ping_api_pb2.UserSetClaimsRequest,
+    ) -> google.protobuf.empty_pb2.Empty:
+        # Wrap the call to the developer's method in a `span` so that it
+        # is traced using its fully-qualified Python name.
+        with IMPORT_reboot_aio_tracing.span(
+                state_name=f"reboot.ping.User('{context.state_id}')",
+                span_name=f"{IMPORT_reboot_aio_tracing.qualified_type_name(self)}.SetClaims()",
+                level=IMPORT_reboot_aio_tracing.TraceLevel.CUSTOMER,
+                python_specific=True,
+        ):
+            typed_request = UserSetClaimsRequestFromProto(request)
+            return UserSetClaimsResponseToProto(
+                await self.SetClaims(
+                    context,
+                    state,
+                    typed_request
                 )
             )
 
@@ -17373,6 +18321,34 @@ class UserServicer(UserBaseServicer):
     ) -> None:
         pass
 
+    # For 'reboot.ping.UserMethods.SetClaims'.
+    # Concrete no-op default for `set_claims`. You may 
+    # override it in your Servicer to use the delivered claims.
+    async def SetClaims(
+        self,
+        context: IMPORT_reboot_aio_contexts.TransactionContext,
+        request: User.SetClaimsRequest,
+    ) -> None:
+        return await self.set_claims(
+            context,
+            request,
+        )
+
+    async def set_claims(
+        self,
+        context: IMPORT_reboot_aio_contexts.TransactionContext,
+        request: User.SetClaimsRequest,
+    ) -> None:
+        """The framework calls this on every sign-in to deliver the
+        user's verified identity claims. `request.claims` is the
+        complete, current set of verified claims (a `dict[str, Any]`
+        keyed by claim name); treat it as a full replace and fully
+        derive any claim-backed User state from it.
+        This makes the method idempotent — re-delivering the same
+        claims is harmless — which is required, since it runs on
+        every sign-in, not just the first."""
+        pass
+
 
     # For 'reboot.ping.UserMethods.CreateCounter'.
     async def _CreateCounter(
@@ -17495,6 +18471,39 @@ class UserServicer(UserBaseServicer):
                 return UserCreateResponseToProto(
                     await instance.Create(
                         context,
+                    )
+                )
+        finally:
+            UserServicer._state.set(None)
+
+    # For 'reboot.ping.UserMethods.SetClaims'.
+    async def _SetClaims(
+        self,
+        context: IMPORT_reboot_aio_contexts.TransactionContext,
+        state: User.State,
+        request: reboot.ping.ping_api_pb2.UserSetClaimsRequest,
+    ) -> google.protobuf.empty_pb2.Empty:
+        # We should have an asyncio task and thus context per request,
+        # let's confirm this assumption by making sure that
+        # `_state is None`.
+        assert UserServicer._state.get() is None
+        UserServicer._state.set(state)
+        try:
+            # Wrap the call to the developer's method in a `span` so that it
+            # is traced using its fully-qualified Python name.
+            instance = self._instance(context.state_id)
+            with IMPORT_reboot_aio_tracing.span(
+                    state_name=f"reboot.ping.User('{context.state_id}')",
+                    span_name=f"{IMPORT_reboot_aio_tracing.qualified_type_name(instance)}.SetClaims()",
+                    level=IMPORT_reboot_aio_tracing.TraceLevel.CUSTOMER,
+                    python_specific=True,
+            ):
+                typed_request = UserSetClaimsRequestFromProto(request)
+
+                return UserSetClaimsResponseToProto(
+                    await instance.SetClaims(
+                        context,
+                        typed_request,
                     )
                 )
         finally:
@@ -24080,6 +25089,9 @@ class User:
 
 
 
+    SetClaimsRequest: IMPORT_typing.TypeAlias = IMPORT_typing.cast(type, IMPORT_api.User.methods['set_claims'].request)
+
+
     __state_type_name__ = IMPORT_reboot_aio_types.StateTypeName("reboot.ping.User")
 
     class CreateCounterTask:
@@ -25186,6 +26198,282 @@ class User:
                 return type(error) in IMPORT_api.User.methods['create'].errors
             return False
 
+    class SetClaimsTask:
+        """Represents a scheduled task running for the
+        state. Note that this is not a coroutine because we are trying
+        to convey the semantics that the task is already running (or
+        will soon be).
+        """
+
+        @classmethod
+        def retrieve(
+            cls,
+            context: IMPORT_reboot_aio_contexts.Context | IMPORT_reboot_aio_external.ExternalContext,
+            *,
+            task_id: IMPORT_rbt_v1alpha1.tasks_pb2.TaskId,
+        ):
+            return cls(context, task_id=task_id)
+
+        def __init__(
+            self,
+            context: IMPORT_reboot_aio_contexts.Context | IMPORT_reboot_aio_external.ExternalContext,
+            *,
+            task_id: IMPORT_rbt_v1alpha1.tasks_pb2.TaskId,
+        ) -> None:
+            # Depending on the context type (inside or outside a Reboot application)
+            # we may or may not know the application ID. If we don't know it, then
+            # the `ExternalContext.gateway` will determine it.
+            #
+            # TODO: in the future we expect to support cross-application calls, in
+            #       which case the developer may explicitly pass in an application ID
+            #       here.
+            self._application_id: IMPORT_typing.Optional[IMPORT_reboot_aio_types.ApplicationId] = None
+            if isinstance(context, IMPORT_reboot_aio_contexts.Context):
+                self._application_id = context.application_id
+            self._channel_manager = context.channel_manager
+            self._task_id = task_id
+
+        @property
+        def task_id(self) -> IMPORT_rbt_v1alpha1.tasks_pb2.TaskId:
+            return self._task_id
+
+        def __await__(self) -> IMPORT_typing.Generator[None, None, None]:
+            """Awaits for task to finish and returns its response."""
+            async def wait_for_task() -> google.protobuf.empty_pb2.Empty:
+                channel = self._channel_manager.get_channel_to_state(
+                    IMPORT_reboot_aio_types.StateTypeName(self._task_id.state_type),
+                    IMPORT_reboot_aio_types.StateRef(self._task_id.state_ref),
+                )
+
+                stub = IMPORT_rbt_v1alpha1.tasks_pb2_grpc.TasksStub(channel)
+
+                try:
+                    call = IMPORT_reboot_aio_stubs.UnaryRetriedCall(
+                        call=None,  # `RetriedCall` can create the call itself.
+                        stub_method=stub.Wait,
+                        method_name="Wait",
+                        request=IMPORT_rbt_v1alpha1.tasks_pb2.WaitRequest(task_id=self._task_id),
+                        metadata=IMPORT_reboot_aio_headers.Headers(
+                            state_ref=IMPORT_reboot_aio_types.StateRef(self._task_id.state_ref),
+                            application_id=self._application_id,
+                        ).to_grpc_metadata(),
+                        aborted_type=IMPORT_reboot.aio.aborted.SystemAborted,
+                    )
+
+                    wait_for_task_response = await call
+                except IMPORT_reboot.aio.aborted.SystemAborted as error:
+                    if error.code == IMPORT_grpc.StatusCode.NOT_FOUND:
+                        raise IMPORT_reboot.aio.aborted.SystemAborted(
+                            IMPORT_rbt_v1alpha1.errors_pb2.UnknownTask()
+                        ) from None
+
+                    raise
+                else:
+                    response_or_error: IMPORT_typing.Optional[IMPORT_google_protobuf_any_pb2.Any] = None
+                    is_error = False
+
+                    if wait_for_task_response.response_or_error.WhichOneof("response_or_error") == "response":
+                        response_or_error = wait_for_task_response.response_or_error.response
+                    else:
+                        is_error = True
+                        response_or_error = wait_for_task_response.response_or_error.error
+
+                    assert response_or_error is not None
+                    assert response_or_error.TypeName() != ""
+
+                    response = google.protobuf.empty_pb2.Empty()
+
+                    if (
+                        not is_error and response_or_error.TypeName() != response.DESCRIPTOR.full_name
+                    ):
+                        raise IMPORT_reboot.aio.aborted.SystemAborted(
+                            IMPORT_rbt_v1alpha1.errors_pb2.InvalidArgument(),
+                            message=
+                            f"task with UUID {IMPORT_uuid.UUID(bytes=self._task_id.task_uuid)} "
+                            f"has a response of type '{response_or_error.TypeName()}' "
+                            "but expecting type 'google.protobuf.empty_pb2.Empty'; "
+                            "are you waiting on a task of the correct method?",
+                        ) from None
+
+                    if is_error:
+                        aborted_type = User.SetClaimsAborted
+
+                        # In Reboot >= 0.40.2 we expect the error to be a `google.rpc.Status`.
+                        if response_or_error.Is(IMPORT_google_rpc_status_pb2.Status.DESCRIPTOR):
+                            status = IMPORT_google_rpc_status_pb2.Status()
+                            response_or_error.Unpack(status)
+                            raise aborted_type.from_status(status)
+
+                        # In Reboot < 0.40.2 workflows throwing declared errors behaved poorly;
+                        # we don't aim to emulate its behavior. Indicate that we don't know the
+                        # reason for the abort.
+                        raise IMPORT_reboot.aio.aborted.SystemAborted(
+                            IMPORT_rbt_v1alpha1.errors_pb2.Unknown(),
+                        )
+
+                    else:
+                        response_or_error.Unpack(response)
+                        return UserSetClaimsResponseFromProto(response)
+
+            return wait_for_task().__await__()
+
+
+    class SetClaimsAborted(IMPORT_reboot.aio.aborted.Aborted):
+
+
+        Error = IMPORT_typing.Union[
+            IMPORT_reboot.aio.aborted.GrpcError,
+            IMPORT_reboot.aio.aborted.RebootError,
+        ]
+
+        METHOD_PROTOBUF_ERROR_TYPES: list[type[IMPORT_google_protobuf_message.Message]] = [
+        ]
+
+        PROTOBUF_ERROR_TYPES: list[type[IMPORT_google_protobuf_message.Message]] = (
+            METHOD_PROTOBUF_ERROR_TYPES +
+            IMPORT_reboot.aio.aborted.GRPC_ERROR_TYPES +
+            IMPORT_reboot.aio.aborted.REBOOT_ERROR_TYPES
+        )
+
+        _error: Error
+
+        MethodProtobufError = IMPORT_typing.Union[
+            IMPORT_reboot.aio.aborted.GrpcError,
+            IMPORT_reboot.aio.aborted.RebootError,
+        ]
+        _method_protobuf_error: MethodProtobufError
+
+        _code: IMPORT_grpc.StatusCode
+        _message: IMPORT_typing.Optional[str]
+
+        def __init__(
+            self,
+            error:  IMPORT_reboot.aio.aborted.GrpcError,
+            *,
+            message: IMPORT_typing.Optional[str] = None,
+            # Do not set this value when constructing in order to
+            # raise. This is only used internally when constructing
+            # from aborted calls.
+            error_types: IMPORT_typing.Sequence[type[MethodProtobufError]] = (
+                METHOD_PROTOBUF_ERROR_TYPES + IMPORT_reboot.aio.aborted.GRPC_ERROR_TYPES
+            ),
+        ):
+            super().__init__()
+
+            self._message = None
+
+            if self.is_declared_error(error):
+                # If the error is a declared error, we should always
+                # store both formats for Pydantic and Protobuf for that
+                # error, so users can access the Pydantic version via
+                # `aborted.error` and the Protobuf version will be used
+                # to send the error over the wire.
+                if isinstance(error, IMPORT_reboot.api.Model):
+                    # Happens when somebody raises an aborted with a Pydantic
+                    # error format, usually in the backend method
+                    # implementation.
+
+                    self._error = error
+
+                else:
+                    # Usually happens on the client side when we are
+                    # constructing an aborted from the `AioRpcError`, so
+                    # the error will be in Protobuf shape, and we want
+                    # to convert it back to Pydantic if possible.
+                    self._method_protobuf_error = error
+
+            else:
+                # Non declared error should be well known Reboot or gRPC
+                # error, which always comes in the Protobuf format, however
+                # it might be a case when the server is using new API and
+                # client is old, so server might send a declared error from
+                # the server perspective, but client doesn't know that it
+                # is a declared error now, so we need to gracefully
+                # cover that case.
+                if isinstance(error, IMPORT_reboot.api.Model):
+                    # Store both formats so users can access the Pydantic
+                    # version via `aborted.error` and the Protobuf version
+                    # will be used to send the error over the wire.
+                    self._error = IMPORT_rbt_v1alpha1.errors_pb2.Unknown()
+                    self._method_protobuf_error = IMPORT_rbt_v1alpha1.errors_pb2.Unknown()
+
+                    self._message = (
+                        "Received a declared error from the server, "
+                        "but the client doesn't know about it; "
+                        "please update the client to the latest version\n"
+                    ) + (
+                        f"Original error: {error.model_dump_json()}\n"
+                    ) + message if message is not None else ""
+
+                # Store both formats so users can access the error via
+                # `aborted.error` and the Protobuf version
+                # will be used to send the error over the wire.
+                self._error = error
+                self._method_protobuf_error = error
+
+            IMPORT_reboot_aio_types.assert_type(self._protobuf_error, error_types)
+
+            code = self.grpc_status_code_from_error(self._protobuf_error)
+
+            if code is None:
+                # Must be a Reboot specific or declared method error.
+                code = IMPORT_grpc.StatusCode.ABORTED
+
+            self._code = code
+
+            self._message = self._message if self._message is not None else message
+
+        @property
+        def error(self) -> Error | MethodProtobufError:
+            return self._error
+
+        @property
+        def _protobuf_error(self) -> MethodProtobufError:
+            return self._method_protobuf_error
+
+        @property
+        def code(self) -> IMPORT_grpc.StatusCode:
+            return self._code
+
+        @property
+        def message(self) -> IMPORT_typing.Optional[str]:
+            return self._message
+
+        @classmethod
+        def from_status(cls, status: IMPORT_google_rpc_status_pb2.Status):
+            error = cls.error_from_google_rpc_status_details(
+                status,
+                cls.PROTOBUF_ERROR_TYPES,
+            )
+
+            message = status.message if len(status.message) > 0 else None
+
+            if error is not None:
+                return cls(error, message=message, error_types=cls.PROTOBUF_ERROR_TYPES)
+
+            error = cls.error_from_google_rpc_status_code(status)
+
+            assert error is not None
+
+            # TODO(benh): also consider getting the type names from
+            # `status.details` and including that in `message` to make
+            # debugging easier.
+
+            return cls(error, message=message)
+
+        @classmethod
+        def from_grpc_aio_rpc_error(cls, aio_rpc_error: IMPORT_grpc.aio.AioRpcError):
+            return cls(
+                cls.error_from_grpc_aio_rpc_error(aio_rpc_error),
+                message=aio_rpc_error.details(),
+            )
+
+        @classmethod
+        def is_declared_error(cls, error: IMPORT_google_protobuf_message.Message | IMPORT_reboot.api.Model) -> bool:
+            if isinstance(error, IMPORT_reboot.api.Model):
+                return type(error) in IMPORT_api.User.methods['set_claims'].errors
+            return False
+
 
     class WeakReference(IMPORT_typing.Generic[User_ScheduleTypeVar]):
 
@@ -25808,6 +27096,75 @@ class User:
             # continue to work, but use the new 'snake_case' method in
             # the new code.
             whoami = Whoami
+            @IMPORT_typing.overload
+            async def SetClaims(
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.TransactionContext | IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+                __request_or_options__: User.SetClaimsRequest,
+                __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+            ) -> None:
+                ...
+
+            @IMPORT_typing.overload
+            async def SetClaims(
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.TransactionContext | IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+                __request_or_options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+                *,
+                claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+            ) -> None:
+                ...
+
+            async def SetClaims( # type: ignore[misc]
+                # In methods which are dealing with user input, (i.e.,
+                # proto message field names), we should use '__double_underscored__'
+                # variables to avoid any potential name conflicts with the method's
+                # parameters.
+                # The '__self__' parameter is a convention in Python to
+                # indicate that this method is a bound method, so we use
+                # '__this__' instead.
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.TransactionContext | IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+                __request_or_options__: IMPORT_typing.Optional[User.SetClaimsRequest | IMPORT_reboot_aio_call.Options] = None,
+                __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+                *,
+                claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+            ) -> None:
+                # UX improvement: check that neither positional argument was accidentally
+                # given a gRPC request type.
+                IMPORT_reboot_aio_types.assert_not_request_type(__context__, request_type=User.SetClaimsRequest)
+                IMPORT_reboot_aio_types.assert_not_request_type(__options__, request_type=User.SetClaimsRequest)
+
+                __request__: IMPORT_typing.Optional[User.SetClaimsRequest] = None
+                if isinstance(__request_or_options__, User.SetClaimsRequest):
+                    assert __request_or_options__ is not None
+                    assert __options__ is None or isinstance(__options__, IMPORT_reboot_aio_call.Options)
+                    __options__ = __options__ or IMPORT_reboot_aio_call.Options()
+
+                    assert claims is UNSET
+
+                    __request__ = __request_or_options__
+                else:
+                    assert __options__ is None
+                    assert __request_or_options__ is None or isinstance(__request_or_options__, IMPORT_reboot_aio_call.Options)
+                    __options__ = __request_or_options__ or IMPORT_reboot_aio_call.Options()
+
+                    __request__ = UserSetClaimsRequestFromInputFields(
+                        claims=claims,
+                    )
+                IMPORT_reboot_aio_types.assert_type(__options__, [IMPORT_reboot_aio_call.Options])
+
+                return await __this__._weak_reference.SetClaims(
+                    __context__,
+                    __request__,
+                    __options__,
+                    __idempotency__=__this__._idempotency,
+                )
+
+            # Keep the original functions on the client, so old code will
+            # continue to work, but use the new 'snake_case' method in
+            # the new code.
+            set_claims = SetClaims
 
         @IMPORT_typing.overload
         def idempotently(self, alias: IMPORT_typing.Optional[str] = None, *, how: IMPORT_reboot_aio_idempotency.How = IMPORT_reboot_aio_idempotency.PER_WORKFLOW) -> User.WeakReference._Idempotently[User_ScheduleTypeVar]:
@@ -26204,6 +27561,92 @@ class User:
             # continue to work, but use the new 'snake_case' method in
             # the new code.
             whoami = Whoami
+            @IMPORT_typing.overload
+            async def SetClaims(
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.TransactionContext,
+                __request_or_options__: User.SetClaimsRequest,
+                __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+            ) -> IMPORT_rbt_v1alpha1.tasks_pb2.TaskId:
+                ...
+
+            @IMPORT_typing.overload
+            async def SetClaims(
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.TransactionContext,
+                __request_or_options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+                *,
+                claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+            ) -> IMPORT_rbt_v1alpha1.tasks_pb2.TaskId:
+                ...
+
+            async def SetClaims( # type: ignore[misc]
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.TransactionContext,
+                __request_or_options__: IMPORT_typing.Optional[User.SetClaimsRequest | IMPORT_reboot_aio_call.Options] = None,
+                __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+                *,
+                claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+            ) -> IMPORT_rbt_v1alpha1.tasks_pb2.TaskId:
+                IMPORT_reboot_aio_types.assert_type(__context__, [IMPORT_reboot_aio_contexts.TransactionContext])
+                # UX improvement: check that neither positional argument was accidentally
+                # given a gRPC request type.
+                IMPORT_reboot_aio_types.assert_not_request_type(__context__, request_type=User.SetClaimsRequest)
+                IMPORT_reboot_aio_types.assert_not_request_type(__options__, request_type=User.SetClaimsRequest)
+
+                __request__: IMPORT_typing.Optional[User.SetClaimsRequest] = None
+                if isinstance(__request_or_options__, User.SetClaimsRequest):
+                    assert __request_or_options__ is not None
+                    assert __options__ is None or isinstance(__options__, IMPORT_reboot_aio_call.Options)
+
+                    assert claims is UNSET
+
+                    __request__ = __request_or_options__
+                else:
+                    assert __options__ is None
+                    assert __request_or_options__ is None or isinstance(__request_or_options__, IMPORT_reboot_aio_call.Options)
+                    __options__ = __request_or_options__
+
+                    __request__ = UserSetClaimsRequestFromInputFields(
+                        claims=claims,
+                    )
+
+                __schedule__: IMPORT_typing.Optional[IMPORT_reboot_time_DateTimeWithTimeZone] = (IMPORT_reboot_time_DateTimeWithTimeZone.now() + __this__._when) if isinstance(
+                    __this__._when, IMPORT_datetime_timedelta
+                ) else __this__._when
+
+                __metadata__: IMPORT_typing.Optional[IMPORT_reboot_aio_types.GrpcMetadata] = None
+                __idempotency__: IMPORT_typing.Optional[IMPORT_reboot_aio_idempotency.Idempotency] = __this__._idempotency
+                __bearer_token__: IMPORT_typing.Optional[str] = None
+
+                if __options__ is not None:
+                    IMPORT_reboot_aio_types.assert_type(__options__, [IMPORT_reboot_aio_call.Options])
+                    if __options__.metadata is not None:
+                        __metadata__ = __options__.metadata
+                    if __options__.bearer_token is not None:
+                        __bearer_token__ = __options__.bearer_token
+
+                # Add scheduling information to the metadata.
+                __metadata__ = (
+                    (IMPORT_reboot_aio_headers.TASK_SCHEDULE,
+                    __schedule__.isoformat() if __schedule__ else ''),
+                ) + (__metadata__ or tuple())
+
+                __task_id__ = await __this__._tasks(
+                    __context__
+                ).SetClaims(
+                    __request__,
+                    idempotency=__idempotency__,
+                    metadata=__metadata__,
+                    bearer_token=__bearer_token__,
+                )
+
+                return __task_id__
+
+            # Keep the original functions on the client, so old code will
+            # continue to work, but use the new 'snake_case' method in
+            # the new code.
+            set_claims = SetClaims
 
         # A `WriterContext` can not call any methods in `_Schedule` to
         # prevent a writer from doing a `Foo.ref()` and trying to
@@ -26429,6 +27872,102 @@ class User:
             # continue to work, but use the new 'snake_case' method in
             # the new code.
             whoami = Whoami
+            @IMPORT_typing.overload
+            async def SetClaims(
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.WriterContext | IMPORT_reboot_aio_contexts.TransactionContext,
+                __request_or_options__: User.SetClaimsRequest,
+                __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+            ) -> IMPORT_rbt_v1alpha1.tasks_pb2.TaskId:
+                ...
+
+            @IMPORT_typing.overload
+            async def SetClaims(
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.WriterContext | IMPORT_reboot_aio_contexts.TransactionContext,
+                __request_or_options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+                *,
+                claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+            ) -> IMPORT_rbt_v1alpha1.tasks_pb2.TaskId:
+                ...
+
+            async def SetClaims( # type: ignore[misc]
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.WriterContext | IMPORT_reboot_aio_contexts.TransactionContext,
+                __request_or_options__: IMPORT_typing.Optional[User.SetClaimsRequest | IMPORT_reboot_aio_call.Options] = None,
+                __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+                *,
+                claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+            ) -> IMPORT_rbt_v1alpha1.tasks_pb2.TaskId:
+                # Only `writer`s and `transaction`s should ``schedule()`, a
+                # `workflow` should `spawn()`.
+                IMPORT_reboot_aio_types.assert_type(__context__, [IMPORT_reboot_aio_contexts.WriterContext, IMPORT_reboot_aio_contexts.TransactionContext])
+
+                # UX improvement: check that neither positional argument was accidentally
+                # given a gRPC request type.
+                IMPORT_reboot_aio_types.assert_not_request_type(__context__, request_type=User.SetClaimsRequest)
+                IMPORT_reboot_aio_types.assert_not_request_type(__options__, request_type=User.SetClaimsRequest)
+
+                __request__: IMPORT_typing.Optional[User.SetClaimsRequest] = None
+                if isinstance(__request_or_options__, User.SetClaimsRequest):
+                    assert __request_or_options__ is not None
+                    assert __options__ is None or isinstance(__options__, IMPORT_reboot_aio_call.Options)
+
+                    assert claims is UNSET
+
+                    __request__ = __request_or_options__
+                else:
+                    assert __options__ is None
+                    assert __request_or_options__ is None or isinstance(__request_or_options__, IMPORT_reboot_aio_call.Options)
+                    __options__ = __request_or_options__
+
+                    __request__ = UserSetClaimsRequestFromInputFields(
+                        claims=claims,
+                    )
+
+                if isinstance(__context__, IMPORT_reboot_aio_contexts.WriterContext):
+                    return (await UserServicerTasks(
+                        context=__context__,
+                        state_ref=__context__._state_ref,
+                    ).SetClaims(
+                        __request__,
+                        schedule=__this__._when,
+                    )).task_id
+
+                __schedule__: IMPORT_typing.Optional[IMPORT_reboot_time_DateTimeWithTimeZone] = (IMPORT_reboot_time_DateTimeWithTimeZone.now() + __this__._when) if isinstance(
+                    __this__._when, IMPORT_datetime_timedelta
+                ) else __this__._when
+
+                __metadata__: IMPORT_typing.Optional[IMPORT_reboot_aio_types.GrpcMetadata] = None
+                __idempotency__: IMPORT_typing.Optional[IMPORT_reboot_aio_idempotency.Idempotency] = __this__._idempotency
+                __bearer_token__: IMPORT_typing.Optional[str] = None
+
+                if __options__ is not None:
+                    IMPORT_reboot_aio_types.assert_type(__options__, [IMPORT_reboot_aio_call.Options])
+                    if __options__.metadata is not None:
+                        __metadata__ = __options__.metadata
+                    if __options__.bearer_token is not None:
+                        __bearer_token__ = __options__.bearer_token
+
+                # Add scheduling information to the metadata.
+                __metadata__ = (
+                    (IMPORT_reboot_aio_headers.TASK_SCHEDULE,
+                    __schedule__.isoformat() if __schedule__ else ''),
+                ) + (__metadata__ or tuple())
+
+                return await __this__._tasks(
+                    __context__
+                ).SetClaims(
+                    __request__,
+                    idempotency=__idempotency__,
+                    metadata=__metadata__,
+                    bearer_token=__bearer_token__,
+                )
+
+            # Keep the original functions on the client, so old code will
+            # continue to work, but use the new 'snake_case' method in
+            # the new code.
+            set_claims = SetClaims
 
         def spawn(
             self,
@@ -26650,6 +28189,95 @@ class User:
             # continue to work, but use the new 'snake_case' method in
             # the new code.
             whoami = Whoami
+            @IMPORT_typing.overload
+            async def SetClaims(
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+                __request_or_options__: User.SetClaimsRequest,
+                __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+            ) -> User.SetClaimsTask:
+                ...
+
+            @IMPORT_typing.overload
+            async def SetClaims(
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+                __request_or_options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+                *,
+                claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+            ) -> User.SetClaimsTask:
+                ...
+
+            async def SetClaims( # type: ignore[misc]
+                __this__,
+                __context__: IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+                __request_or_options__: IMPORT_typing.Optional[User.SetClaimsRequest | IMPORT_reboot_aio_call.Options] = None,
+                __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+                *,
+                claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+            ) -> User.SetClaimsTask:
+                IMPORT_reboot_aio_types.assert_type(__context__, [IMPORT_reboot_aio_contexts.WorkflowContext, IMPORT_reboot_aio_external.ExternalContext])
+                # UX improvement: check that neither positional argument was accidentally
+                # given a gRPC request type.
+                IMPORT_reboot_aio_types.assert_not_request_type(__context__, request_type=User.SetClaimsRequest)
+                IMPORT_reboot_aio_types.assert_not_request_type(__options__, request_type=User.SetClaimsRequest)
+
+
+                __request__: IMPORT_typing.Optional[User.SetClaimsRequest] = None
+                if isinstance(__request_or_options__, User.SetClaimsRequest):
+                    assert __request_or_options__ is not None
+                    assert __options__ is None or isinstance(__options__, IMPORT_reboot_aio_call.Options)
+
+                    assert claims is UNSET
+
+                    __request__ = __request_or_options__
+                else:
+                    assert __options__ is None
+                    assert __request_or_options__ is None or isinstance(__request_or_options__, IMPORT_reboot_aio_call.Options)
+                    __options__ = __request_or_options__
+
+                    __request__ = UserSetClaimsRequestFromInputFields(
+                        claims=claims,
+                    )
+                __schedule__: IMPORT_typing.Optional[IMPORT_reboot_time_DateTimeWithTimeZone] = (IMPORT_reboot_time_DateTimeWithTimeZone.now() + __this__._when) if isinstance(
+                    __this__._when, IMPORT_datetime_timedelta
+                ) else __this__._when
+
+                __metadata__: IMPORT_typing.Optional[IMPORT_reboot_aio_types.GrpcMetadata] = None
+                __idempotency__: IMPORT_typing.Optional[IMPORT_reboot_aio_idempotency.Idempotency] = __this__._idempotency
+                __bearer_token__: IMPORT_typing.Optional[str] = None
+
+                if __options__ is not None:
+                    IMPORT_reboot_aio_types.assert_type(__options__, [IMPORT_reboot_aio_call.Options])
+                    if __options__.metadata is not None:
+                        __metadata__ = __options__.metadata
+                    if __options__.bearer_token is not None:
+                        __bearer_token__ = __options__.bearer_token
+
+                # Add scheduling information to the metadata.
+                __metadata__ = (
+                    (IMPORT_reboot_aio_headers.TASK_SCHEDULE,
+                    __schedule__.isoformat() if __schedule__ else ''),
+                ) + (__metadata__ or tuple())
+
+                __task_id__ = await __this__._tasks(
+                    __context__
+                ).SetClaims(
+                    __request__,
+                    idempotency=__idempotency__,
+                    metadata=__metadata__,
+                    bearer_token=__bearer_token__,
+                )
+
+                return User.SetClaimsTask(
+                    __context__,
+                    task_id=__task_id__,
+                )
+
+            # Keep the original functions on the client, so old code will
+            # continue to work, but use the new 'snake_case' method in
+            # the new code.
+            set_claims = SetClaims
 
         async def read(
             self,
@@ -26894,6 +28522,102 @@ class User:
         # continue to work, but use the new 'snake_case' method in
         # the new code.
         whoami = Whoami
+        @IMPORT_typing.overload
+        async def SetClaims(
+            __this__,
+            __context__: IMPORT_reboot_aio_contexts.TransactionContext | IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+            __request_or_options__: User.SetClaimsRequest,
+            __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+            *,
+            __idempotency__: IMPORT_typing.Optional[IMPORT_reboot_aio_idempotency.Idempotency] = None,
+        ) -> None:
+            ...
+
+        @IMPORT_typing.overload
+        async def SetClaims(
+            __this__,
+            __context__: IMPORT_reboot_aio_contexts.TransactionContext | IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+            __request_or_options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+            *,
+            __idempotency__: IMPORT_typing.Optional[IMPORT_reboot_aio_idempotency.Idempotency] = None,
+            claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+        ) -> None:
+            ...
+
+        async def SetClaims( # type: ignore[misc]
+            __this__,
+            __context__: IMPORT_reboot_aio_contexts.TransactionContext | IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+            __request_or_options__: IMPORT_typing.Optional[User.SetClaimsRequest | IMPORT_reboot_aio_call.Options] = None,
+            __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+            *,
+            __idempotency__: IMPORT_typing.Optional[IMPORT_reboot_aio_idempotency.Idempotency] = None,
+            claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+        ) -> None:
+            # UX improvement: check that neither positional argument was accidentally
+            # given a gRPC request type.
+            IMPORT_reboot_aio_types.assert_not_request_type(__context__, request_type=User.SetClaimsRequest)
+            IMPORT_reboot_aio_types.assert_not_request_type(__options__, request_type=User.SetClaimsRequest)
+
+            __request__: IMPORT_typing.Optional[User.SetClaimsRequest] = None
+            if isinstance(__request_or_options__, User.SetClaimsRequest):
+                assert __request_or_options__ is not None
+                assert __options__ is None or isinstance(__options__, IMPORT_reboot_aio_call.Options)
+
+                assert claims is UNSET
+
+                __request__ = __request_or_options__
+            else:
+                assert __options__ is None
+                assert __request_or_options__ is None or isinstance(__request_or_options__, IMPORT_reboot_aio_call.Options)
+                __options__ = __request_or_options__
+
+                __request__ = UserSetClaimsRequestFromInputFields(
+                    claims=claims,
+                )
+
+            # Within a `workflow`, all "bare" calls are
+            # `per_workflow()` calls, unless we're within a control
+            # loop, in which case they are syntactic sugar for
+            # `per_iteration()`.
+            if __idempotency__ is None:
+                if isinstance(__context__, IMPORT_reboot_aio_contexts.WorkflowContext):
+                    return await (
+                        __this__.per_iteration() if __context__.within_loop()
+                        else __this__.per_workflow()
+                    ).SetClaims(
+                        __context__,
+                        __request__,
+                        __options__ or IMPORT_reboot_aio_call.Options(),
+                    )
+                elif isinstance(__context__, IMPORT_reboot_aio_external.InitializeContext):
+                    return await __this__.idempotently().SetClaims(
+                        __context__,
+                        __request__,
+                        __options__ or IMPORT_reboot_aio_call.Options(),
+                    )
+
+            __metadata__: IMPORT_typing.Optional[IMPORT_reboot_aio_types.GrpcMetadata] = None
+            __bearer_token__: IMPORT_typing.Optional[str] = None
+            if __options__ is not None:
+                IMPORT_reboot_aio_types.assert_type(__options__, [IMPORT_reboot_aio_call.Options])
+                if __options__.metadata is not None:
+                    __metadata__ = __options__.metadata
+                if __options__.bearer_token is not None:
+                    __bearer_token__ = __options__.bearer_token
+
+            return UserSetClaimsResponseFromProto(
+                await __this__._workflow(__context__).SetClaims(
+                    __request__,
+                    idempotency=__idempotency__,
+                    metadata=__metadata__,
+                    bearer_token=__bearer_token__,
+                )
+            )
+
+        # Keep the original functions on the client, so old code will
+        # continue to work, but use the new 'snake_case' method in
+        # the new code.
+        set_claims = SetClaims
 
     class _Forall:
 
@@ -27035,6 +28759,81 @@ class User:
         # continue to work, but use the new 'snake_case' method in
         # the new code.
         whoami = Whoami
+        @IMPORT_typing.overload
+        async def SetClaims(
+            __this__,
+            __context__: IMPORT_reboot_aio_contexts.TransactionContext | IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+            __request_or_options__: User.SetClaimsRequest,
+            __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+        ) -> list[None]:
+            ...
+
+        @IMPORT_typing.overload
+        async def SetClaims(
+            __this__,
+            __context__: IMPORT_reboot_aio_contexts.TransactionContext | IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+            __request_or_options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+            *,
+            claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+        ) -> list[None]:
+            ...
+
+        async def SetClaims( # type: ignore[misc]
+            # In methods which are dealing with user input, (i.e.,
+            # proto message field names), we should use '__double_underscored__'
+            # variables to avoid any potential name conflicts with the method's
+            # parameters.
+            # The '__self__' parameter is a convention in Python to
+            # indicate that this method is a bound method, so we use
+            # '__this__' instead.
+            __this__,
+            __context__: IMPORT_reboot_aio_contexts.TransactionContext | IMPORT_reboot_aio_contexts.WorkflowContext | IMPORT_reboot_aio_external.ExternalContext,
+            __request_or_options__: IMPORT_typing.Optional[User.SetClaimsRequest | IMPORT_reboot_aio_call.Options] = None,
+            __options__: IMPORT_typing.Optional[IMPORT_reboot_aio_call.Options] = None,
+            *,
+            claims: dict[str, IMPORT_typing.Any] | Unset = UNSET,
+        ) -> list[None]:
+            if isinstance(__request_or_options__, User.SetClaimsRequest):
+                assert __request_or_options__ is not None
+                assert __options__ is None or isinstance(__options__, IMPORT_reboot_aio_call.Options)
+                __options__ = __options__ or IMPORT_reboot_aio_call.Options()
+
+                assert claims is UNSET
+
+                return await IMPORT_asyncio.gather(
+                    *[
+                        User.ref(
+                            id
+                        ).SetClaims(
+                            __context__,
+                            __request_or_options__,
+                            __options__,
+                        ) for id in __this__._ids
+                    ]
+                )
+            else:
+                assert __options__ is None
+                assert __request_or_options__ is None or isinstance(__request_or_options__, IMPORT_reboot_aio_call.Options)
+                __options__ = __request_or_options__ or IMPORT_reboot_aio_call.Options()
+
+                return await IMPORT_asyncio.gather(
+                    *[
+                        User.ref(
+                            id
+                        ).SetClaims(
+                            __context__,
+                            UserSetClaimsRequestFromInputFields(
+                                claims=claims,
+                            ),
+                            __options__,
+                        ) for id in __this__._ids
+                    ]
+                )
+
+        # Keep the original functions on the client, so old code will
+        # continue to work, but use the new 'snake_case' method in
+        # the new code.
+        set_claims = SetClaims
 
     @classmethod
     def forall(cls, ids: IMPORT_typing.Iterable[str]) -> User._Forall:

--- a/tests/reboot/ping_api_rbt.golden.py
+++ b/tests/reboot/ping_api_rbt.golden.py
@@ -8505,8 +8505,8 @@ class UserServicerMiddleware(IMPORT_reboot_aio_internals_middleware.Middleware):
                 context.auth = auth
 
                 # The framework's `set_claims` method should only ever
-                # be app-internal only; even the owning user shouldn't
-                # be trusted to call it, since the identity provider's
+                # be app-internal; even the owning user shouldn't be
+                # trusted to call it, since the identity provider's
                 # claims may deliver info like "validated email address"
                 # and other things we don't trust the user to set
                 # directly.
@@ -17292,7 +17292,7 @@ class UserBaseServicer(IMPORT_reboot_aio_servicers.Servicer):
             reboot_context = IMPORT_reboot_mcp_context.get_reboot_context(ctx)
             id = IMPORT_reboot_mcp_context.get_mcp_user_id(ctx)
             # State is auto-constructed when the user's
-            # JWT is minted; see `_auto_construct`.
+            # JWT is minted; see `_authenticated`.
             ref = User.ref(id)
             return await ref.create_counter(reboot_context, request)
 
@@ -17309,7 +17309,7 @@ class UserBaseServicer(IMPORT_reboot_aio_servicers.Servicer):
             reboot_context = IMPORT_reboot_mcp_context.get_reboot_context(ctx)
             id = IMPORT_reboot_mcp_context.get_mcp_user_id(ctx)
             # State is auto-constructed when the user's
-            # JWT is minted; see `_auto_construct`.
+            # JWT is minted; see `_authenticated`.
             ref = User.ref(id)
             return await ref.list_counters(reboot_context)
 
@@ -17326,25 +17326,36 @@ class UserBaseServicer(IMPORT_reboot_aio_servicers.Servicer):
             reboot_context = IMPORT_reboot_mcp_context.get_reboot_context(ctx)
             id = IMPORT_reboot_mcp_context.get_mcp_user_id(ctx)
             # State is auto-constructed when the user's
-            # JWT is minted; see `_auto_construct`.
+            # JWT is minted; see `_authenticated`.
             ref = User.ref(id)
             return await ref.whoami(reboot_context)
 
         pass  # End of _add_mcp.
 
     @staticmethod
-    async def _auto_construct(
+    async def _authenticated(
         context: IMPORT_reboot_aio_external.ExternalContext,
         state_id: str,
+        claims: IMPORT_typing.Optional[
+            IMPORT_typing.Mapping[str, IMPORT_typing.Any]
+        ] = None,
     ) -> None:
-        """Auto-construct a `User` state."""
-        # Some states have `_auto_construct` called many times, e.g. a
-        # per-user state may get auto-constructed at the start of every
-        # MCP session. We derive a deterministic idempotency key from the
-        # state ID so that repeated calls (even from different contexts)
-        # are a NOOP. We prefer this over catching the
-        # `StateAlreadyExists` error that would otherwise result, since
-        # that logs an `ERROR` to user-visible logs.
+        """Record that a user authenticated: construct their
+        `User` if it does not exist yet, then, when
+        `claims` is given, deliver their verified identity claims.
+
+        `claims=None` means the caller has no claims information for
+        this authentication (e.g. a token refresh, which never
+        consults the identity provider); it never means "no claims"
+        and never clears previously delivered claims.
+        """
+        # A `User` may be authenticated many times,
+        # e.g. a per-user state on every sign-in. We derive a
+        # deterministic idempotency key from the state ID so that the
+        # construct is a NOOP once the state exists (even across
+        # different contexts). We prefer this over catching the
+        # `StateAlreadyConstructed` error that would otherwise result,
+        # since that logs an `ERROR` to user-visible logs.
         idempotency_key = IMPORT_uuid.uuid5(
             IMPORT_uuid.NAMESPACE_URL,
             f"urn:dev.reboot:auto-construct:User:{state_id}",
@@ -17352,6 +17363,18 @@ class UserBaseServicer(IMPORT_reboot_aio_servicers.Servicer):
         await User.idempotently(
             key=idempotency_key,
         ).create(context, state_id)
+        # The two calls are deliberately sequential rather than wrapped
+        # in one transaction: an idempotent construct followed by a
+        # full-replace `set_claims` compose convergently.
+        # `set_claims` runs on every sign-in (`.always()`)
+        # because even if `set_state(claims=FOO)` has been called before,
+        # it could be that `set_state(claims=BAR)` was called since
+        # then, and `set_state(claims=FOO)` would have an effect again -
+        # we want to converge on the most recently delivered claims.
+        if claims is not None:
+            await User.ref(state_id).always().set_claims(
+                context, claims=claims
+            )
 
     def ref(
         self,

--- a/tests/reboot/pydantic/auto_construct_user/BUILD.bazel
+++ b/tests/reboot/pydantic/auto_construct_user/BUILD.bazel
@@ -20,6 +20,7 @@ py_reboot_library_from_pydantic(
 py_library(
     name = "servicer_py",
     srcs = ["servicer.py"],
+    visibility = ["//tests/reboot:__subpackages__"],
     deps = [
         ":servicer_api_py",
         ":servicer_py_reboot",

--- a/tests/reboot/pydantic/auto_construct_user/servicer.py
+++ b/tests/reboot/pydantic/auto_construct_user/servicer.py
@@ -12,6 +12,12 @@ from tests.reboot.pydantic.auto_construct_user.servicer_api_rbt import (
 
 class UserServicer(User.Servicer):
 
+    def authorizer(self):
+        # A deliberately permissive authorizer: the tests prove that
+        # even a blanket `allow()` cannot expose the `set_claims`
+        # claims-delivery method to external callers.
+        return allow()
+
     async def create(self, context: TransactionContext) -> None:
         """Override the auto-constructed `create` to also construct a
         `Profile` for this user; a `Transaction` can call other state
@@ -20,8 +26,23 @@ class UserServicer(User.Servicer):
         await Profile.create(context, profile_id)
         self.state.profile_id = profile_id
 
+    async def set_claims(
+        self,
+        context: TransactionContext,
+        request: User.SetClaimsRequest,
+    ) -> None:
+        """Override the injected `set_claims` to transcribe the
+        delivered email claim; a full replace, so it reads the
+        complete claims set from the request every time."""
+        self.state.email = request.claims.get("email", "")
+        self.state.update_count += 1
+
     async def get(self, context: ReaderContext) -> User.GetResponse:
-        return User.GetResponse(profile_id=self.state.profile_id)
+        return User.GetResponse(
+            profile_id=self.state.profile_id,
+            email=self.state.email,
+            update_count=self.state.update_count,
+        )
 
 
 class ProfileServicer(Profile.Servicer):

--- a/tests/reboot/pydantic/auto_construct_user/servicer_api.py
+++ b/tests/reboot/pydantic/auto_construct_user/servicer_api.py
@@ -14,13 +14,22 @@ class ProfileGetResponse(Model):
 
 
 # The `User` state is auto-constructed `PER_USER_ID`, so the framework
-# injects a reserved, overridable `create` factory onto it.
+# injects a reserved, overridable `create` factory and a reserved,
+# overridable `set_claims` claims-delivery method onto it.
 class UserState(Model):
     profile_id: str = Field(tag=1, default="")
+    # The email identity claim most recently delivered via
+    # `set_claims`.
+    email: str = Field(tag=2, default="")
+    # How many claims deliveries have reached `set_claims`, so tests
+    # can observe which deliveries executed.
+    update_count: int = Field(tag=3, default=0)
 
 
 class UserGetResponse(Model):
     profile_id: str = Field(tag=1)
+    email: str = Field(tag=2, default="")
+    update_count: int = Field(tag=3, default=0)
 
 
 api = API(

--- a/tests/reboot/pydantic/auto_construct_user/test.py
+++ b/tests/reboot/pydantic/auto_construct_user/test.py
@@ -106,6 +106,70 @@ class AutoConstructUserTest(unittest.IsolatedAsyncioTestCase):
             )
         self.assertIsInstance(aborted.exception.error, PermissionDenied)
 
+    async def test_authenticated_delivers_claims(self) -> None:
+        # `_authenticated` with claims constructs the state (if
+        # needed) and delivers the claims through `set_claims`.
+        await UserServicer._authenticated(
+            self.internal,
+            state_id=_USER_ID,
+            claims={
+                "email": "jane@example.com",
+                "email_verified": True
+            },
+        )
+
+        user_response = await User.ref(_USER_ID).get(self.context)
+        self.assertEqual(
+            user_response.profile_id,
+            f"profile-{_USER_ID}",
+        )
+        self.assertEqual(user_response.email, "jane@example.com")
+
+    async def test_authenticated_without_claims_skips_set_claims(
+        self,
+    ) -> None:
+        # `_authenticated()` with no claims (e.g. a token refresh)
+        # ensures the state exists but delivers nothing, so it never
+        # clears previously delivered claims.
+        await UserServicer._authenticated(
+            self.internal,
+            state_id=_USER_ID,
+            claims={"email": "jane@example.com"},
+        )
+        await UserServicer._authenticated(self.internal, state_id=_USER_ID)
+
+        user_response = await User.ref(_USER_ID).get(self.context)
+        self.assertEqual(user_response.email, "jane@example.com")
+        self.assertEqual(user_response.update_count, 1)
+
+    async def test_repeated_delivery_converges_after_a_b_a(self) -> None:
+        # Every sign-in delivers, so a user whose email changes from A
+        # to B and back to A ends up with A: state converges on the
+        # most recently delivered claims rather than deduplicating a
+        # "seen" value.
+        for email in ("a@example.com", "b@example.com", "a@example.com"):
+            await UserServicer._authenticated(
+                self.internal,
+                state_id=_USER_ID,
+                claims={"email": email},
+            )
+
+        user_response = await User.ref(_USER_ID).get(self.context)
+        self.assertEqual(user_response.email, "a@example.com")
+        self.assertEqual(user_response.update_count, 3)
+
+    async def test_mint_with_claims_delivers(self) -> None:
+        # The test harness mirrors production: minting a token with
+        # claims delivers them through the same chokepoint, so a
+        # freshly minted user has their claims transcribed.
+        await self.rbt.make_valid_oauth_access_token(
+            user_id="minted-user",
+            claims={"email": "minted@example.com"},
+        )
+
+        user_response = await User.ref("minted-user").get(self.internal)
+        self.assertEqual(user_response.email, "minted@example.com")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/reboot/pydantic/auto_construct_user/test.py
+++ b/tests/reboot/pydantic/auto_construct_user/test.py
@@ -1,4 +1,5 @@
 import unittest
+from rbt.v1alpha1.errors_pb2 import PermissionDenied
 from reboot.aio.applications import Application
 from reboot.aio.tests import Reboot
 from tests.reboot.pydantic.auto_construct_user.servicer import (
@@ -16,7 +17,9 @@ _USER_ID = "test-user"
 class AutoConstructUserTest(unittest.IsolatedAsyncioTestCase):
     """The auto-constructed `User.create` is a `Transaction`, so an
     overriding servicer can construct other state machines as part of
-    user creation."""
+    user creation. The framework separately delivers the user's
+    verified identity claims through the injected `set_claims`
+    method."""
 
     async def asyncSetUp(self) -> None:
         self.rbt = Reboot()
@@ -28,10 +31,16 @@ class AutoConstructUserTest(unittest.IsolatedAsyncioTestCase):
         )
         # An authenticated context whose user-id matches the `User`
         # state-id, which is what the framework requires to reach an
-        # auto-constructed `User`.
+        # auto-constructed `User`. Minting the token also constructs
+        # the `User` as a side effect.
         self.context = await self.rbt.create_external_context_as(
             name=f"test-{self.id()}",
             user_id=_USER_ID,
+        )
+        # An app-internal context that may also call `User`.
+        self.internal = self.rbt.create_external_context(
+            name=f"internal-{self.id()}",
+            app_internal=True,
         )
 
     async def asyncTearDown(self) -> None:
@@ -68,6 +77,34 @@ class AutoConstructUserTest(unittest.IsolatedAsyncioTestCase):
             user_response.profile_id,
             f"profile-{_USER_ID}",
         )
+
+    async def test_set_claims_copies_email(self) -> None:
+        # The injected `set_claims` delivers the user's verified
+        # identity claims; our test's override copies the email address
+        # into state.
+        await User.ref(_USER_ID).set_claims(
+            self.internal,
+            claims={"email": "jane@example.com"},
+        )
+
+        user_response = await User.ref(_USER_ID).get(self.context)
+        self.assertEqual(user_response.email, "jane@example.com")
+        self.assertEqual(user_response.update_count, 1)
+
+    async def test_set_claims_is_app_internal_only(self) -> None:
+        # Even the owning user may not call `set_claims` on their own
+        # state: claims are provided by the identity provider and may
+        # contain things (like a validated email address) that we don't
+        # trust the user to set directly. The servicer's blanket
+        # `allow()` authorizer does not loosen this — the generated
+        # middleware rejects external callers before consulting any
+        # authorizer.
+        with self.assertRaises(User.SetClaimsAborted) as aborted:
+            await User.ref(_USER_ID).set_claims(
+                self.context,
+                claims={"email": "spoofed@example.com"},
+            )
+        self.assertIsInstance(aborted.exception.error, PermissionDenied)
 
 
 if __name__ == "__main__":

--- a/tests/reboot/pydantic/auto_construct_user/test.py
+++ b/tests/reboot/pydantic/auto_construct_user/test.py
@@ -49,7 +49,7 @@ class AutoConstructUserTest(unittest.IsolatedAsyncioTestCase):
     async def test_create_transaction_constructs_related_state(
         self,
     ) -> None:
-        await UserServicer._auto_construct(self.context, state_id=_USER_ID)
+        await UserServicer._authenticated(self.context, state_id=_USER_ID)
 
         # The override recorded the `Profile` it created on the `User`.
         user_response = await User.ref(_USER_ID).get(self.context)
@@ -69,8 +69,8 @@ class AutoConstructUserTest(unittest.IsolatedAsyncioTestCase):
         # Auto-construction may be triggered repeatedly (e.g. at the
         # start of every session); doing so must be a no-op rather
         # than re-running the constructing transaction.
-        await UserServicer._auto_construct(self.context, state_id=_USER_ID)
-        await UserServicer._auto_construct(self.context, state_id=_USER_ID)
+        await UserServicer._authenticated(self.context, state_id=_USER_ID)
+        await UserServicer._authenticated(self.context, state_id=_USER_ID)
 
         user_response = await User.ref(_USER_ID).get(self.context)
         self.assertEqual(

--- a/tests/reboot/pydantic/auto_construct_user_unhandled_claims/BUILD.bazel
+++ b/tests/reboot/pydantic/auto_construct_user_unhandled_claims/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("//reboot:pydantic_to_proto.bzl", "py_reboot_library_from_pydantic")
+
+py_library(
+    name = "servicer_api_py",
+    srcs = ["servicer_api.py"],
+    deps = [
+        "//reboot:api_py",
+    ],
+)
+
+py_reboot_library_from_pydantic(
+    name = "servicer_py_reboot",
+    py_deps = [
+        ":servicer_api_py",
+    ],
+    pydantic = ":servicer_api.py",
+)
+
+py_library(
+    name = "servicer_py",
+    srcs = ["servicer.py"],
+    visibility = ["//tests/reboot:__subpackages__"],
+    deps = [
+        ":servicer_api_py",
+        ":servicer_py_reboot",
+    ],
+)
+
+py_test(
+    name = "test_py",
+    srcs = ["test.py"],
+    main = "test.py",
+    deps = [
+        ":servicer_py",
+        "//reboot/aio:applications_py",
+        "//reboot/aio:tests_py",
+    ],
+)

--- a/tests/reboot/pydantic/auto_construct_user_unhandled_claims/servicer.py
+++ b/tests/reboot/pydantic/auto_construct_user_unhandled_claims/servicer.py
@@ -1,0 +1,20 @@
+from reboot.aio.auth.authorizers import allow
+from reboot.aio.contexts import ReaderContext
+from tests.reboot.pydantic.auto_construct_user_unhandled_claims.servicer_api_rbt import (
+    User,
+)
+
+
+class UserServicer(User.Servicer):
+    """A `User` servicer that overrides neither the injected `create`
+    nor the injected `set_claims`: the tests prove that delivering
+    identity claims to it fails through the injected `set_claims`
+    default rather than silently discarding the claims."""
+
+    def authorizer(self):
+        # A blanket `allow()`; the tests are about the injected
+        # `set_claims` default, not authorization.
+        return allow()
+
+    async def get(self, context: ReaderContext) -> User.GetResponse:
+        return User.GetResponse(email=self.state.email)

--- a/tests/reboot/pydantic/auto_construct_user_unhandled_claims/servicer_api.py
+++ b/tests/reboot/pydantic/auto_construct_user_unhandled_claims/servicer_api.py
@@ -1,0 +1,31 @@
+from reboot.api import API, Field, Methods, Model, Reader, Type
+
+
+# The `User` state is auto-constructed `PER_USER_ID`, so the framework
+# injects a reserved, overridable `create` factory and a reserved,
+# overridable `set_claims` claims-delivery method onto it. This test's
+# servicer deliberately overrides neither, so that delivering claims
+# exercises the injected `set_claims` default.
+class UserState(Model):
+    # An email identity claim that a `set_claims` override would fill
+    # in; it stays at its default here because this servicer never
+    # consumes delivered claims.
+    email: str = Field(tag=1, default="")
+
+
+class UserGetResponse(Model):
+    email: str = Field(tag=1, default="")
+
+
+api = API(
+    User=Type(
+        state=UserState,
+        methods=Methods(
+            get=Reader(
+                request=None,
+                response=UserGetResponse,
+                mcp=None,
+            ),
+        ),
+    ),
+)

--- a/tests/reboot/pydantic/auto_construct_user_unhandled_claims/test.py
+++ b/tests/reboot/pydantic/auto_construct_user_unhandled_claims/test.py
@@ -1,0 +1,67 @@
+import unittest
+from rbt.v1alpha1.errors_pb2 import Unknown
+from reboot.aio.applications import Application
+from reboot.aio.tests import Reboot
+from tests.reboot.pydantic.auto_construct_user_unhandled_claims.servicer import (
+    UserServicer,
+)
+from tests.reboot.pydantic.auto_construct_user_unhandled_claims.servicer_api_rbt import (
+    User,
+)
+
+_USER_ID = "test-user"
+
+
+class UnhandledClaimsTest(unittest.IsolatedAsyncioTestCase):
+    """A `User` whose servicer never overrides the injected
+    `set_claims`. Delivering identity claims to it must fail loudly
+    rather than silently discard them, so a developer who requested
+    claims but forgot to consume them finds out at sign-in."""
+
+    async def asyncSetUp(self) -> None:
+        self.rbt = Reboot()
+        await self.rbt.start()
+        await self.rbt.up(Application(servicers=[UserServicer]))
+        # An app-internal context, the only kind allowed to reach the
+        # claims-delivery `set_claims`.
+        self.internal = self.rbt.create_external_context(
+            name=f"internal-{self.id()}",
+            app_internal=True,
+        )
+
+    async def asyncTearDown(self) -> None:
+        await self.rbt.stop()
+
+    async def test_delivering_claims_without_override_fails(self) -> None:
+        # Construct the `User` first without claims (a claimless mint,
+        # like a token refresh), so the failure below is the injected
+        # `set_claims` default, not a missing state.
+        await self.rbt.make_valid_oauth_access_token(user_id=_USER_ID)
+
+        with self.assertRaises(User.SetClaimsAborted) as aborted:
+            await User.ref(_USER_ID).set_claims(
+                self.internal,
+                claims={"email": "jane@example.com"},
+            )
+        # An uncaught servicer error propagates to the caller as
+        # `Unknown`; the injected default logs a message explaining how
+        # to fix it (override `set_claims`) to the server logs.
+        self.assertIsInstance(aborted.exception.error, Unknown)
+
+        # The failed delivery left the state untouched.
+        user_response = await User.ref(_USER_ID).get(self.internal)
+        self.assertEqual(user_response.email, "")
+
+    async def test_minting_a_token_with_claims_fails(self) -> None:
+        # The production mint path delivers claims through the same
+        # chokepoint, so minting a token with claims for an
+        # unhandled-claims `User` fails the sign-in.
+        with self.assertRaises(User.SetClaimsAborted):
+            await self.rbt.make_valid_oauth_access_token(
+                user_id="minted-user",
+                claims={"email": "minted@example.com"},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/reboot/pydantic/methods/servicer.py
+++ b/tests/reboot/pydantic/methods/servicer.py
@@ -13,6 +13,9 @@ from reboot.aio.contexts import (
     WriterContext,
 )
 from tests.reboot.pydantic.methods.servicer_api import (
+    ARBITRARY_JSON_METADATA,
+    ARBITRARY_JSON_NOTE,
+    ARBITRARY_JSON_TAGS,
     AnotherError,
     ArbitraryData,
     ComplexTypesRequest,
@@ -134,6 +137,19 @@ class TestServicer(Test.Servicer):
             "b": "option1",
         }
 
+        # Exercise `dict[str, Any]` (a `map<string,
+        # google.protobuf.Value>`): set a heterogeneous JSON value that
+        # `get_snapshot` reads back out of storage, proving the runtime
+        # round-trips the values verbatim.
+        self.state.metadata = ARBITRARY_JSON_METADATA
+
+        # Exercise a bare `Any` (a single `google.protobuf.Value`) and
+        # a `list[Any]` (a `repeated google.protobuf.Value`): set them
+        # so `get_snapshot` reads them back out of storage, proving the
+        # runtime round-trips top-level and list `Any` values verbatim.
+        self.state.note = ARBITRARY_JSON_NOTE
+        self.state.tags = ARBITRARY_JSON_TAGS
+
     def authorizer(self):
 
         def update_state_rule(
@@ -227,6 +243,9 @@ class TestServicer(Test.Servicer):
                 current_float=self.state.float_value,
                 current_bool=self.state.bool_value,
                 current_data=self.state.data_value,
+                current_metadata=self.state.metadata,
+                current_note=self.state.note,
+                current_tags=self.state.tags,
             )
         )
 

--- a/tests/reboot/pydantic/methods/servicer_api.py
+++ b/tests/reboot/pydantic/methods/servicer_api.py
@@ -9,9 +9,50 @@ from reboot.api import (
     Workflow,
     Writer,
 )
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 LiteralType = Literal["option1", "option2", "option3"]
+
+# A heterogeneous JSON value used to exercise the `dict[str, Any]`
+# (`map<string, google.protobuf.Value>`) round-trip: strings, a bool,
+# a number, a nested object, a list, and a null.
+ARBITRARY_JSON_METADATA: dict[str, Any] = {
+    "email": "jane@example.com",
+    "email_verified": True,
+    "login_count": 3,
+    "address": {
+        "city": "Springfield",
+        "zipcode": "00000",
+    },
+    "roles": ["admin", "user"],
+    "middle_name": None,
+}
+
+# A bare `Any` value (a field typed just `Any`, not inside a `dict` or
+# `list`) used to exercise the top-level `Any` round-trip: a nested
+# JSON object mixing a string, a number, a bool, a list, and a null.
+ARBITRARY_JSON_NOTE: Any = {
+    "summary": "hello",
+    "attempts": 2,
+    "flagged": True,
+    "labels": ["a", "b"],
+    "extra": None,
+}
+
+# A `list[Any]` value used to exercise the `Any`-inside-`list`
+# round-trip: heterogeneous elements (a string, a number, a bool, a
+# null, a nested object, and a nested list), each of which lowers to a
+# `google.protobuf.Value`.
+ARBITRARY_JSON_TAGS: list[Any] = [
+    "admin",
+    7,
+    True,
+    None,
+    {
+        "nested": "object"
+    },
+    ["nested", "list"],
+]
 
 
 class ArbitraryData(Model):
@@ -83,6 +124,18 @@ class State(Model):
         current_float: float = Field(tag=3)
         current_bool: bool = Field(tag=4)
         current_data: ArbitraryData = Field(tag=5)
+        # `dict[str, Any]` — a `map<string, google.protobuf.Value>`
+        # carrying free-form JSON values; snapshotting it here proves
+        # it round-trips out through a response message too.
+        current_metadata: dict[str, Any] = Field(tag=6, default_factory=dict)
+        # A bare `Any` — a `google.protobuf.Value` carrying an
+        # arbitrary JSON value; snapshotting it proves a top-level
+        # `Any` round-trips out through a response message too.
+        current_note: Any = Field(tag=7)
+        # `list[Any]` — a `repeated google.protobuf.Value` carrying
+        # heterogeneous JSON values; snapshotting it proves it
+        # round-trips out through a response message too.
+        current_tags: list[Any] = Field(tag=8, default_factory=list)
 
     ### Required fields. ###
 
@@ -107,6 +160,22 @@ class State(Model):
     literal_list_value: list[LiteralType] = Field(tag=21)
     # `dict[str, <Literal>]` — a `map` with `enum` values.
     literal_dict_value: dict[str, LiteralType] = Field(tag=22)
+    # `dict[str, Any]` — a `map<string, google.protobuf.Value>`
+    # carrying arbitrary, heterogeneous JSON values (strings, bools,
+    # numbers, nested objects, lists, nulls). We want to ensure codegen
+    # lowers it to a `google.protobuf.Value` map and that the runtime
+    # round-trips the values verbatim.
+    metadata: dict[str, Any] = Field(tag=23, default_factory=dict)
+    # A bare `Any` — a single `google.protobuf.Value` carrying an
+    # arbitrary JSON value. We want to ensure codegen lowers a
+    # top-level `Any` (not just a `dict`/`list` element) to a
+    # `google.protobuf.Value` and that the runtime round-trips it.
+    note: Any = Field(tag=24)
+    # `list[Any]` — a `repeated google.protobuf.Value` carrying
+    # arbitrary, heterogeneous JSON values. We want to ensure codegen
+    # lowers an `Any` list element to a `google.protobuf.Value` and
+    # that the runtime round-trips the values verbatim.
+    tags: list[Any] = Field(tag=25, default_factory=list)
 
     ### Empty default values. ###
     str_default_value: str = Field(

--- a/tests/reboot/pydantic/methods/test.py
+++ b/tests/reboot/pydantic/methods/test.py
@@ -9,6 +9,9 @@ from reboot.aio.external import InitializeContext
 from reboot.aio.tests import Reboot
 from tests.reboot.pydantic.methods.servicer import TestServicer
 from tests.reboot.pydantic.methods.servicer_api import (
+    ARBITRARY_JSON_METADATA,
+    ARBITRARY_JSON_NOTE,
+    ARBITRARY_JSON_TAGS,
     AnotherError,
     ArbitraryData,
     GetSnapshotResponse,
@@ -205,6 +208,9 @@ class RebootTestCase(unittest.IsolatedAsyncioTestCase):
                 current_float=3.14,
                 current_bool=True,
                 current_data=expected_data,
+                current_metadata=ARBITRARY_JSON_METADATA,
+                current_note=ARBITRARY_JSON_NOTE,
+                current_tags=ARBITRARY_JSON_TAGS,
             )
         )
 
@@ -227,6 +233,9 @@ class RebootTestCase(unittest.IsolatedAsyncioTestCase):
                 current_float=3.14,
                 current_bool=False,
                 current_data=expected_data,
+                current_metadata=ARBITRARY_JSON_METADATA,
+                current_note=ARBITRARY_JSON_NOTE,
+                current_tags=ARBITRARY_JSON_TAGS,
             )
         )
 
@@ -282,6 +291,9 @@ class RebootTestCase(unittest.IsolatedAsyncioTestCase):
                         "initialized",
                     ],
                 ),
+                current_metadata=ARBITRARY_JSON_METADATA,
+                current_note=ARBITRARY_JSON_NOTE,
+                current_tags=ARBITRARY_JSON_TAGS,
             )
         )
 


### PR DESCRIPTION
Previously, an auto-constructed `User` learned nothing about the person it represents: signing in through `oauth=` created the actor with a user ID and nothing else, and the verified identity information the identity provider holds (email, name, ... — the so-called "claims") were never available to the application. That's a problem for many applications that need things like a user's email or full name, for example also for Reboot Cloud.

This PR delivers verified identity provider claims to `User`. Application developers request the claims they want when constructing their identity provider:

```py
oauth=OAuthProviderByEnvironment(
    dev=Development(claims=["email"]),
    prod=Google(claims=["email"]),
),
```

Each provider declares which claims it can deliver and rejects any others at construction. When the developer requests a claim, the provider will add whatever OAuth scopes that claim needs automatically (e.g. `Google(claims=["email"])` adds the `email` scope). Claims can be remapped to a different name, for when your dev and prod providers disagree on what a claim is called (`claims={"email": "verified-email"}`). If no claims are requested, behavior is unchanged from what it was previously.

To use claims, application developers (if they want) override the implementation of a new `SetClaims`/`set_claims` transaction on their auto-constructed state type:

```py
# On `UserServicer`:
async def set_claims(
    self,
    context: TransactionContext,
    request: SetClaimsRequest,
) -> None:
    self.state.email = request.claims.get("email", "")
```

This approach mirrors the auto-constructor (`Create`/`create`) already present for `User`s, except that `create` is called exactly once (it's a constructor), whereas `set_claims` may be called many times (any time a claim may have changed).

Claims may have any type (string, bool, ...) so arrive as a plain `dict[str, Any]`, carried on the wire as a `map<string, google.protobuf.Value>`.

Calling `set_claims` is full-replace — "here is the complete, current set of verified claims" — and therefore idempotent, so if Reboot is unsure whether claims have changed it can simply rerun `set_claims`.

Calling `set_claims` happens on identity provider code exchange (every time a token is minted; the only moment fresh verified claims exist): first auto-construction's `create` happens (if needed), then `set_claims`. It's also possible (in future PRs) to hav webhooks call `set_claims`, so this design makes it possible for claims to update "reactively" too.

Please see individual commits for the steps needed to get there.
