### PR TITLE
Run fork PR CI with `pull_request_target` behind maintainer approval

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,11 +1,20 @@
 name: Build and Test
 
 on:
-  # We don't run CI on our main branch, only on pull requests to the
-  # main branch. The main branch can only change via pull requests, and
-  # checks on those pull requests must pass before merging to main, so
-  # checks on main are redundant.
-  pull_request:
+  # We don't run CI on our `main` branch, only on pull requests to the
+  # `main` branch. The `main` branch can only change via pull requests,
+  # and checks on those pull requests must pass before merging to
+  # `main`, so checks on `main` are redundant.
+  #
+  # We use `pull_request_target` rather than `pull_request` so that CI
+  # can reach the Bazel remote cache secrets even on pull requests from
+  # forks (`pull_request` withholds secrets from fork runs, and without
+  # the cache our jobs cannot run). The workflow definition itself comes
+  # from the base branch, but the jobs below check out and run the PR's
+  # own code, so a fork PR executes untrusted code with our secrets. The
+  # `approve-fork-pr` job holds every such run for maintainer approval
+  # before any of that code runs; see its comment for the full model.
+  pull_request_target:
     # Run CI on pull requests. Passing checks will be required to merge.
     branches:
       - "**"
@@ -25,14 +34,55 @@ concurrency:
   #
   # See documentation about the `github` context variables here:
   #   https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Do not cancel runs on the main branch. On the main branch we want every
-  # commit to be tested.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  #
+  # We key the group on the PR number, not `github.ref`: under
+  # `pull_request_target` `github.ref` is the base branch (e.g.
+  # `refs/heads/main`) and so is identical for every PR, which would
+  # collapse all PRs into one group. `merge_group` runs have no PR
+  # number, so they fall back to `github.ref` (the unique merge-queue
+  # ref).
+  group: >-
+    ${{ github.workflow }}-${{
+    github.event.pull_request.number || github.ref }}
+  # Cancel superseded runs for a PR when it gets new commits, but let
+  # every `merge_group` run finish so each queued commit is tested.
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 jobs:
+  # External fork pull requests run with `pull_request_target`, which
+  # grants our secrets and a read/write token even though the PR's own
+  # (untrusted) code is what gets built and tested by the jobs below.
+  # Hold every such run here until a maintainer has read the PR and
+  # approved the `fork-pr-ci` environment. Same-repo pull requests (from
+  # people who already have write access) and `merge_group` runs are
+  # already trusted, so this job is skipped and CI proceeds with no
+  # approval step. Every downstream job `needs` this one, so nothing
+  # checks out or runs PR code before the approval clears.
+  #
+  # SETUP REQUIRED: the `fork-pr-ci` environment must exist in the
+  # repository settings with "Required reviewers" configured. Without
+  # that protection rule this job passes immediately and provides no
+  # checkpoint at all.
+  approve-fork-pr:
+    name: Approve fork PR CI
+    if: >-
+      ${{ github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-latest
+    environment: fork-pr-ci
+    steps:
+      - name: Await maintainer approval
+        run: echo "A maintainer approved running CI for this fork PR."
+
   check-code-style:
     name: Check Code Style
+    # Runs only after `approve-fork-pr` clears (or is skipped for a
+    # trusted run); see that job.
+    needs: approve-fork-pr
+    if: >-
+      ${{ !cancelled() &&
+          (needs.approve-fork-pr.result == 'success' ||
+           needs.approve-fork-pr.result == 'skipped') }}
     uses: ./.github/workflows/devcontainer.yml
     # The nested job needs write permissions, which means this job also needs
     # them.
@@ -52,6 +102,13 @@ jobs:
 
   build-reboot-linux-x86_x64-public:
     name: Build public repo for Linux x86_64
+    # Runs only after `approve-fork-pr` clears (or is skipped for a
+    # trusted run); see that job.
+    needs: approve-fork-pr
+    if: >-
+      ${{ !cancelled() &&
+          (needs.approve-fork-pr.result == 'success' ||
+           needs.approve-fork-pr.result == 'skipped') }}
     uses: ./.github/workflows/devcontainer.yml
     # The nested job needs write permissions, which means this job also needs
     # them.
@@ -75,6 +132,13 @@ jobs:
 
   test-react-native-maestro:
     name: Test React Native mobile app (Maestro)
+    # Runs only after `approve-fork-pr` clears (or is skipped for a
+    # trusted run); see that job.
+    needs: approve-fork-pr
+    if: >-
+      ${{ !cancelled() &&
+          (needs.approve-fork-pr.result == 'success' ||
+           needs.approve-fork-pr.result == 'skipped') }}
     uses: ./.github/workflows/devcontainer.yml
     permissions:
       packages: write
@@ -125,6 +189,13 @@ jobs:
 
   build-reboot-linux-arm64:
     name: Build public repo for Linux arm64
+    # Runs only after `approve-fork-pr` clears (or is skipped for a
+    # trusted run); see that job.
+    needs: approve-fork-pr
+    if: >-
+      ${{ !cancelled() &&
+          (needs.approve-fork-pr.result == 'success' ||
+           needs.approve-fork-pr.result == 'skipped') }}
     uses: ./.github/workflows/devcontainer.yml
     permissions:
       packages: write
@@ -173,11 +244,27 @@ jobs:
 
   build-reboot-documentation:
     name: Build Reboot documentation
+    # Runs only after `approve-fork-pr` clears (or is skipped for a
+    # trusted run); see that job.
+    needs: approve-fork-pr
+    if: >-
+      ${{ !cancelled() &&
+          (needs.approve-fork-pr.result == 'success' ||
+           needs.approve-fork-pr.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # Under `pull_request_target`, checkout defaults to the
+          # base branch; check out the PR head so CI tests the
+          # proposed code (`merge_group` falls back to the queued
+          # merge commit). `allow-unsafe-pr-checkout` is required
+          # now that `actions/checkout` refuses fork PR heads by
+          # default; it is safe because the run first waits for
+          # maintainer approval via the `fork-pr-ci` environment.
+          ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
           show-progress: false
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -194,6 +281,13 @@ jobs:
 
   test-manylinux-x86_64:
     name: Test Manylinux x86_64
+    # Runs only after `approve-fork-pr` clears (or is skipped for a
+    # trusted run); see that job.
+    needs: approve-fork-pr
+    if: >-
+      ${{ !cancelled() &&
+          (needs.approve-fork-pr.result == 'success' ||
+           needs.approve-fork-pr.result == 'skipped') }}
     uses: ./.github/workflows/manylinux.yml
     secrets: inherit
     with:
@@ -208,6 +302,13 @@ jobs:
 
   test-manylinux-arm64:
     name: Test Manylinux arm64
+    # Runs only after `approve-fork-pr` clears (or is skipped for a
+    # trusted run); see that job.
+    needs: approve-fork-pr
+    if: >-
+      ${{ !cancelled() &&
+          (needs.approve-fork-pr.result == 'success' ||
+           needs.approve-fork-pr.result == 'skipped') }}
     uses: ./.github/workflows/manylinux.yml
     secrets: inherit
     with:
@@ -222,6 +323,13 @@ jobs:
 
   build-reboot-MacOS-arm64:
     name: Build public repo for MacOS arm64
+    # Runs only after `approve-fork-pr` clears (or is skipped for a
+    # trusted run); see that job.
+    needs: approve-fork-pr
+    if: >-
+      ${{ !cancelled() &&
+          (needs.approve-fork-pr.result == 'success' ||
+           needs.approve-fork-pr.result == 'skipped') }}
     uses: ./.github/workflows/reboot_macos_environment.yml
     secrets: inherit
     with:
@@ -244,7 +352,7 @@ jobs:
 
         # 3) If this is a PR labelled "reboot-release", also drop flaky
         # tests.
-        if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && \
+        if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ] && \
           jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH" \
             | grep -qx reboot-release; then
           echo "NOTE: reboot-release label found — excluding flaky tests"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -21,6 +21,12 @@ on:
   merge_group:
     # Required if we want to use GitHub's Merge Queue feature. See:
     #   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
+  # Manual trigger so a maintainer can run a branch's own workflow
+  # definition before merge. Under `pull_request_target` the workflow
+  # YAML always comes from the base branch, so edits to this file are
+  # otherwise untested until merged; `workflow_dispatch` runs the
+  # selected branch's version (with secrets) to validate them.
+  workflow_dispatch:
 
 concurrency:
   # Have at most one of these workflows running per branch, cancelling older

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -256,14 +256,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Under `pull_request_target`, checkout defaults to the
-          # base branch; check out the PR head so CI tests the
-          # proposed code (`merge_group` falls back to the queued
-          # merge commit). `allow-unsafe-pr-checkout` is required
+          # Under `pull_request_target`, checkout defaults to the base
+          # branch; check out the PR head so CI tests the proposed
+          # code. On non-PR events (e.g. `merge_group`) there is no
+          # `pull_request`, so `ref` falls back to `github.sha`, the
+          # queued merge commit. `allow-unsafe-pr-checkout` is required
           # now that `actions/checkout` refuses fork PR heads by
           # default; it is safe because the run first waits for
           # maintainer approval via the `fork-pr-ci` environment.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: true
           show-progress: false
       - name: Setup Node

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -103,14 +103,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Under `pull_request_target`, checkout defaults to the
-          # base branch; check out the PR head so CI tests the
-          # proposed code (`merge_group` falls back to the queued
-          # merge commit). `allow-unsafe-pr-checkout` is required
+          # Under `pull_request_target`, checkout defaults to the base
+          # branch; check out the PR head so CI tests the proposed
+          # code. On non-PR events (e.g. `merge_group`) there is no
+          # `pull_request`, so `ref` falls back to `github.sha`, the
+          # queued merge commit. `allow-unsafe-pr-checkout` is required
           # now that `actions/checkout` refuses fork PR heads by
           # default; it is safe because the run first waits for
           # maintainer approval via the `fork-pr-ci` environment.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: true
           submodules: recursive
           show-progress: false

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -103,6 +103,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # Under `pull_request_target`, checkout defaults to the
+          # base branch; check out the PR head so CI tests the
+          # proposed code (`merge_group` falls back to the queued
+          # merge commit). `allow-unsafe-pr-checkout` is required
+          # now that `actions/checkout` refuses fork PR heads by
+          # default; it is safe because the run first waits for
+          # maintainer approval via the `fork-pr-ci` environment.
+          ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
           submodules: recursive
           show-progress: false
 

--- a/.github/workflows/development_containers_build_test.yml
+++ b/.github/workflows/development_containers_build_test.yml
@@ -6,14 +6,50 @@ on:
   # manually. We also do NOT test on pushes to `main`, only on PRs:
   # `main` can only change via PR, and PRs must pass all checks to
   # merge, so checks on `main` are redundant.
-  pull_request:
+  #
+  # We use `pull_request_target` rather than `pull_request` so that CI
+  # can reach the Bazel remote cache secrets even on pull requests from
+  # forks. The jobs below check out and run the PR's own code, so a fork
+  # PR executes untrusted code with our secrets; the `approve-fork-pr`
+  # job holds every such run for maintainer approval first.
+  pull_request_target:
   merge_group:
     # Required if we want to use GitHub's Merge Queue feature. See:
     #   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
 
 jobs:
+  # External fork pull requests run with `pull_request_target`, which
+  # grants our secrets and a read/write token even though the PR's own
+  # (untrusted) code is what gets built and tested below. Hold every
+  # such run here until a maintainer has read the PR and approved the
+  # `fork-pr-ci` environment. Same-repo pull requests and `merge_group`
+  # runs are already trusted, so this job is skipped and CI proceeds
+  # with no approval step.
+  #
+  # SETUP REQUIRED: the `fork-pr-ci` environment must exist in the
+  # repository settings with "Required reviewers" configured. Without
+  # that protection rule this job passes immediately and provides no
+  # checkpoint at all.
+  approve-fork-pr:
+    name: Approve fork PR CI
+    if: >-
+      ${{ github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-latest
+    environment: fork-pr-ci
+    steps:
+      - name: Await maintainer approval
+        run: echo "A maintainer approved running CI for this fork PR."
+
   build-test-development-containers:
     name: Build and Test Development Containers
+    # Runs only after `approve-fork-pr` clears (or is skipped for a
+    # trusted run); see that job.
+    needs: approve-fork-pr
+    if: >-
+      ${{ !cancelled() &&
+          (needs.approve-fork-pr.result == 'success' ||
+           needs.approve-fork-pr.result == 'skipped') }}
     uses: ./.github/workflows/development_containers_build_test_push.yml
     permissions:
       # The workflow we're about to run requires the following permissions,

--- a/.github/workflows/development_containers_build_test.yml
+++ b/.github/workflows/development_containers_build_test.yml
@@ -16,6 +16,12 @@ on:
   merge_group:
     # Required if we want to use GitHub's Merge Queue feature. See:
     #   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
+  # Manual trigger so a maintainer can run a branch's own workflow
+  # definition before merge. Under `pull_request_target` the workflow
+  # YAML always comes from the base branch, so edits to this file are
+  # otherwise untested until merged; `workflow_dispatch` runs the
+  # selected branch's version (with secrets) to validate them.
+  workflow_dispatch:
 
 jobs:
   # External fork pull requests run with `pull_request_target`, which

--- a/.github/workflows/development_containers_build_test_push.yml
+++ b/.github/workflows/development_containers_build_test_push.yml
@@ -100,14 +100,15 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@v4
         with:
-          # Under `pull_request_target`, checkout defaults to the
-          # base branch; check out the PR head so CI tests the
-          # proposed code (`merge_group` falls back to the queued
-          # merge commit). `allow-unsafe-pr-checkout` is required
+          # Under `pull_request_target`, checkout defaults to the base
+          # branch; check out the PR head so CI tests the proposed
+          # code. On non-PR events (e.g. `merge_group`) there is no
+          # `pull_request`, so `ref` falls back to `github.sha`, the
+          # queued merge commit. `allow-unsafe-pr-checkout` is required
           # now that `actions/checkout` refuses fork PR heads by
           # default; it is safe because the run first waits for
           # maintainer approval via the `fork-pr-ci` environment.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: true
           show-progress: false
 

--- a/.github/workflows/development_containers_build_test_push.yml
+++ b/.github/workflows/development_containers_build_test_push.yml
@@ -100,6 +100,15 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@v4
         with:
+          # Under `pull_request_target`, checkout defaults to the
+          # base branch; check out the PR head so CI tests the
+          # proposed code (`merge_group` falls back to the queued
+          # merge commit). `allow-unsafe-pr-checkout` is required
+          # now that `actions/checkout` refuses fork PR heads by
+          # default; it is safe because the run first waits for
+          # maintainer approval via the `fork-pr-ci` environment.
+          ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
           show-progress: false
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -48,6 +48,15 @@ jobs:
       - name: Checkout reboot-dev/mono
         uses: actions/checkout@v4
         with:
+          # Under `pull_request_target`, checkout defaults to the
+          # base branch; check out the PR head so CI tests the
+          # proposed code (`merge_group` falls back to the queued
+          # merge commit). `allow-unsafe-pr-checkout` is required
+          # now that `actions/checkout` refuses fork PR heads by
+          # default; it is safe because the run first waits for
+          # maintainer approval via the `fork-pr-ci` environment.
+          ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
           submodules: recursive
           show-progress: false
 

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -48,14 +48,15 @@ jobs:
       - name: Checkout reboot-dev/mono
         uses: actions/checkout@v4
         with:
-          # Under `pull_request_target`, checkout defaults to the
-          # base branch; check out the PR head so CI tests the
-          # proposed code (`merge_group` falls back to the queued
-          # merge commit). `allow-unsafe-pr-checkout` is required
+          # Under `pull_request_target`, checkout defaults to the base
+          # branch; check out the PR head so CI tests the proposed
+          # code. On non-PR events (e.g. `merge_group`) there is no
+          # `pull_request`, so `ref` falls back to `github.sha`, the
+          # queued merge commit. `allow-unsafe-pr-checkout` is required
           # now that `actions/checkout` refuses fork PR heads by
           # default; it is safe because the run first waits for
           # maintainer approval via the `fork-pr-ci` environment.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: true
           submodules: recursive
           show-progress: false

--- a/.github/workflows/reboot_macos_environment.yml
+++ b/.github/workflows/reboot_macos_environment.yml
@@ -172,6 +172,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # Under `pull_request_target`, checkout defaults to the
+          # base branch; check out the PR head so CI tests the
+          # proposed code (`merge_group` falls back to the queued
+          # merge commit). `allow-unsafe-pr-checkout` is required
+          # now that `actions/checkout` refuses fork PR heads by
+          # default; it is safe because the run first waits for
+          # maintainer approval via the `fork-pr-ci` environment.
+          ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
           submodules: recursive
           show-progress: false
 

--- a/.github/workflows/reboot_macos_environment.yml
+++ b/.github/workflows/reboot_macos_environment.yml
@@ -172,14 +172,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Under `pull_request_target`, checkout defaults to the
-          # base branch; check out the PR head so CI tests the
-          # proposed code (`merge_group` falls back to the queued
-          # merge commit). `allow-unsafe-pr-checkout` is required
+          # Under `pull_request_target`, checkout defaults to the base
+          # branch; check out the PR head so CI tests the proposed
+          # code. On non-PR events (e.g. `merge_group`) there is no
+          # `pull_request`, so `ref` falls back to `github.sha`, the
+          # queued merge commit. `allow-unsafe-pr-checkout` is required
           # now that `actions/checkout` refuses fork PR heads by
           # default; it is safe because the run first waits for
           # maintainer approval via the `fork-pr-ci` environment.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: true
           submodules: recursive
           show-progress: false


### PR DESCRIPTION
Under the `pull_request` event, GitHub **withholds secrets from pull requests opened from forks**. Our CI needs the Bazel remote cache credentials (`GCP_REMOTE_CACHE_CREDENTIALS_BASE64`) to run at all, so fork PRs currently can't run CI. Switching the two auto-triggered workflows — `build_and_test.yml` and `development_containers_build_test.yml` — from `pull_request` to `pull_request_target` gives fork runs access to those secrets.

This wasn't quite a one-line change, because:

* `pull_request_target` runs in the **trusted base-branch context**. That has two consequences we have to handle, or the change is silently broken and unsafe:

  1. **It bypasses GitHub's fork-PR "approve to run" checkpoint.** Unlike `pull_request`, a `pull_request_target` run is *not* held for the maintainer approval we rely on today — it would run automatically on every fork PR, with secrets. ([GitHub Security Lab](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/))
  2. **It checks out the base branch by default,** not the PR's code — so CI would test the wrong thing.

* Making CI actually test the PR's code means checking out the fork's (untrusted) head with secrets present — the classic **"pwn request"** shape. So we re-introduce a human checkpoint, implemented correctly for this trigger.

What this PR has:

- **Trigger:** `pull_request` → `pull_request_target` in both workflows
- **Approval checkpoint:** a new `approve-fork-pr` job requires the **`fork-pr-ci` environment**. Every job that checks out or runs PR code `needs` it, so nothing untrusted runs until it clears.
  - **External fork PRs:** the environment's required reviewers must approve first — same review-then-approve flow as today, just moved to a per-run "Approve deployment" button.
  - **Same-repo (maintainer) PRs and `merge_group`:** the job is skipped and CI proceeds with no extra approval.
- **Checkout:** the five `actions/checkout` steps now take `ref: ${{ github.event.pull_request.head.sha }}` with `allow-unsafe-pr-checkout: true` — required now that `actions/checkout` [refuses fork heads under `pull_request_target` by default](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/) (backported to v4 on 2026-07-20). The flag is deliberately conspicuous for review.
- **Concurrency:** `build_and_test.yml` now keys its concurrency group on the PR number instead of `github.ref`, which under `pull_request_target` is the shared base branch and would otherwise collapse every PR into one group. `cancel-in-progress` now keys on the event so PR iterations still cancel but every `merge_group` commit runs to completion.
- **Event-name check:** the MacOS `reboot-release` flaky-test branch now matches `pull_request_target`.

The above required that I manually created a GitHub "environment" named `fork-pr-ci`; see [here](https://github.com/reboot-dev/reboot/settings/environments/18506219297/edit).