### PR TITLE
OAuth: add Ory support, including "reactive" claims

### DIFF
--- a/reboot/aio/applications.py
+++ b/reboot/aio/applications.py
@@ -778,6 +778,7 @@ class Application:
                     auto_construct_state_type_full_names
                 ),
                 authenticated=self._authenticated,
+                claims_changed=self._set_claims_if_exists,
                 allowed_origins=self._allowed_origins,
             )
             self._oauth_server = oauth_server
@@ -827,6 +828,36 @@ class Application:
             *(
                 servicer_cls.
                 _authenticated(context, state_id=user_id, claims=claims)
+                for servicer_cls in (self._servicers or [])
+                if servicer_cls._is_auto_construct
+            )
+        )
+
+    async def _set_claims_if_exists(
+        self,
+        context: ExternalContext,
+        user_id: str,
+        claims: Mapping[str, Any],
+    ) -> None:
+        """Deliver a user's verified identity claims to every
+        auto-construct state type that already exists for them, never
+        constructing one.
+
+        This is the entrypoint for identity changes that arrive
+        outside a sign-in — an identity provider webhook, which fires
+        instance-wide for every identity in the provider — so it must
+        not materialize state for an identity that never signed into
+        this application. A user whose state does not exist yet is
+        skipped; their next sign-in delivers current claims itself.
+
+        `context` is app-internal: claims ride the delivery, so only
+        trusted app code may assert them.
+        """
+        await asyncio.gather(
+            *(
+                servicer_cls._set_claims_if_exists(
+                    context, state_id=user_id, claims=claims
+                )
                 for servicer_cls in (self._servicers or [])
                 if servicer_cls._is_auto_construct
             )

--- a/reboot/aio/auth/BUILD.bazel
+++ b/reboot/aio/auth/BUILD.bazel
@@ -69,6 +69,7 @@ py_library(
     deps = [
         "//reboot:run_environments_py",
         "//reboot/aio:exceptions_py",
+        "//reboot/aio:external_py",
         "//reboot/aio:http_py",
         "//reboot/crypto:root_keys_py",
         "@com_github_reboot_dev_reboot//log:log_py",

--- a/reboot/aio/auth/oauth_providers.py
+++ b/reboot/aio/auth/oauth_providers.py
@@ -76,6 +76,39 @@ def _scopes_from_response(granted: Any, requested: list[str]) -> list[str]:
     return requested
 
 
+def _normalize_domain(domain: Optional[str]) -> str:
+    """Strip a leading scheme and any trailing slash from a
+    provider's `domain` so both `tenant.example.com` and the full
+    `https://tenant.example.com/` form work; returns `""` for a
+    missing domain (caught later by `validate()`).
+    """
+    if not domain:
+        return ""
+    parsed = urlparse(domain)
+    # `urlparse("tenant.example.com")` puts everything in `path` (no
+    # scheme), whereas `urlparse("https://tenant.example.com")` puts
+    # it in `netloc`; take whichever is populated.
+    host = parsed.netloc or parsed.path
+    return host.strip("/")
+
+
+def _decoded_id_token(
+    id_token: Optional[str],
+) -> Optional[dict[str, Any]]:
+    """Decode an OIDC ID token's claims, or `None` if there's no
+    token.
+
+    Decodes without verifying the signature: the token was received
+    directly from the provider's token endpoint over TLS, so the
+    transport guarantees authenticity (the same reasoning `Google`
+    applies). We don't restrict `algorithms` because the signature
+    isn't checked and providers may sign with RS256 or HS256.
+    """
+    if not id_token:
+        return None
+    return jwt.decode(id_token, options={"verify_signature": False})
+
+
 def origin_from_request(request: Request) -> str:
     """
     Derive the server's origin (`scheme://host`) from request headers.
@@ -789,40 +822,7 @@ class Auth0(RegisteredOAuthProvider):
             store_tokens=store_tokens,
             claims=claims,
         )
-        self._domain = self._normalize_domain(domain)
-
-    @staticmethod
-    def _normalize_domain(domain: Optional[str]) -> str:
-        """Strip a leading scheme and any trailing slash from an Auth0
-        `domain` so both `your-tenant.auth0.com` and the full
-        `https://your-tenant.auth0.com/` form work; returns `""` for a
-        missing domain (caught later by `validate()`).
-        """
-        if not domain:
-            return ""
-        parsed = urlparse(domain)
-        # `urlparse("tenant.auth0.com")` puts everything in `path` (no
-        # scheme), whereas `urlparse("https://tenant.auth0.com")` puts it
-        # in `netloc`; take whichever is populated.
-        host = parsed.netloc or parsed.path
-        return host.strip("/")
-
-    @staticmethod
-    def _decoded_id_token(
-        id_token: Optional[str],
-    ) -> Optional[dict[str, Any]]:
-        """Decode an OIDC ID token's claims, or `None` if there's no
-        token.
-
-        Decodes without verifying the signature: we received this token
-        directly from the provider's token endpoint over TLS, so the
-        transport guarantees authenticity (the same reasoning `Google`
-        applies). We don't restrict `algorithms` because the signature
-        isn't checked and Auth0 tenants may sign with RS256 or HS256.
-        """
-        if not id_token:
-            return None
-        return jwt.decode(id_token, options={"verify_signature": False})
+        self._domain = _normalize_domain(domain)
 
     @property
     def _authorization_endpoint(self) -> str:
@@ -897,7 +897,7 @@ class Auth0(RegisteredOAuthProvider):
                 response.raise_for_status()
                 token_response = await response.json()
 
-            decoded = self._decoded_id_token(token_response.get("id_token"))
+            decoded = _decoded_id_token(token_response.get("id_token"))
             user_id = decoded.get("sub") if decoded is not None else None
             # The ID token carries the requested identity claims (we
             # requested the scopes they need); surface whichever are
@@ -945,6 +945,188 @@ class Auth0(RegisteredOAuthProvider):
         or `None` when token storage isn't enabled or no access token came
         back. Auth0 only returns a `refresh_token` when `offline_access`
         was requested (see `authorization_url`).
+        """
+        if not self._store_tokens:
+            return None
+        access_token = token_response.get("access_token")
+        if access_token is None:
+            return None
+        return OAuthTokens(
+            access_token=access_token,
+            refresh_token=token_response.get("refresh_token"),
+            expires_at=_expires_at_from_expires_in(
+                token_response.get("expires_in")
+            ),
+            scopes=_scopes_from_response(
+                token_response.get("scope"),
+                self._requested_scopes(),
+            ),
+        )
+
+
+class Ory(RegisteredOAuthProvider):
+    """
+    Ory OAuth provider (OpenID Connect).
+
+    Works against an Ory Network project or a self-hosted Ory
+    deployment serving the OAuth2 (Hydra) endpoints. All endpoints
+    live under the project's domain (e.g.
+    `your-slug.projects.oryapis.com`), so like `Auth0` this provider
+    takes a `domain`. Create an OAuth2 client in the Ory project with
+    the authorization-code grant, add Reboot's callback
+    (`<base>/__/oauth/callback`) to its redirect URIs, and pass the
+    client's ID/secret here.
+
+    Obtains the user ID from the OIDC ID token's `sub` claim — for
+    Ory that is the Kratos identity ID (assuming the default,
+    non-pairwise subject configuration). Pass `claims=` to deliver
+    the identity's details as identity claims: the scopes they need
+    (`email` for the email claims, `profile` for the rest) are
+    requested automatically — make sure the OAuth2 client is allowed
+    to request them.
+    """
+
+    # `openid` is the minimum OIDC scope; yields an ID token with the
+    # `sub` claim (the Kratos identity ID).
+    _REQUIRED_SCOPE = "openid"
+
+    # Ory's built-in mapping of an identity onto OIDC claims, each
+    # keyed to the standard scope that makes it appear: the `email`
+    # claims come from the identity's first verifiable email address,
+    # `name` / `given_name` / `family_name` / `username` / `website`
+    # from the identity's traits, and `updated_at` from its top-level
+    # field of that name. Ory emits `username` where the OIDC
+    # standard names `preferred_username`. Which of these a project
+    # populates depends on its Kratos identity schema; absent claims
+    # are simply omitted (see `_presented_claims`). See
+    # https://www.ory.com/docs/oauth2-oidc/openid-connect-claims-scope-custom.
+    _AVAILABLE_CLAIMS = {
+        "email": "email",
+        "email_verified": "email",
+        "name": "profile",
+        "given_name": "profile",
+        "family_name": "profile",
+        "username": "profile",
+        "website": "profile",
+        "updated_at": "profile",
+    }
+
+    # Ory grants a refresh token only when `offline_access` is
+    # requested (like Auth0); see `authorization_url`.
+    _OFFLINE_ACCESS_SCOPE = "offline_access"
+
+    def __init__(
+        self,
+        *,
+        # The Ory project domain, e.g.
+        # `your-slug.projects.oryapis.com`. A full `https://...` URL
+        # or a trailing slash is tolerated.
+        domain: Optional[str],
+        client_id: Optional[str],
+        client_secret: Optional[str],
+        scopes: Optional[list[str]] = None,
+        store_tokens: bool = False,
+        claims: Optional[Sequence[str] | Mapping[str, str]] = None,
+    ):
+        super().__init__(
+            client_id=client_id,
+            client_secret=client_secret,
+            scopes=scopes,
+            store_tokens=store_tokens,
+            claims=claims,
+        )
+        self._domain = _normalize_domain(domain)
+
+    @property
+    def _authorization_endpoint(self) -> str:
+        return f"https://{self._domain}/oauth2/auth"
+
+    @property
+    def _token_endpoint(self) -> str:
+        return f"https://{self._domain}/oauth2/token"
+
+    @property
+    def token_service_id(self) -> str:
+        # Ory serves one project per domain, so the project domain
+        # (e.g. "your-slug.projects.oryapis.com") names the service.
+        return self._domain
+
+    def validate(self) -> None:
+        super().validate()
+        if not self._domain:
+            raise InputError(
+                reason="Ory requires a non-empty `domain`.",
+            )
+
+    def authorization_url(
+        self,
+        state: str,
+        redirect_uri: str,
+    ) -> str:
+        scopes = self._requested_scopes()
+        # Ory asks for refresh tokens via the `offline_access` scope.
+        # Only request it when we're actually capturing tokens, to
+        # avoid asking the user for offline access we'd never use.
+        if self._store_tokens and self._OFFLINE_ACCESS_SCOPE not in scopes:
+            scopes = scopes + [self._OFFLINE_ACCESS_SCOPE]
+        params = {
+            "client_id": self._client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": " ".join(scopes),
+            "state": state,
+        }
+        return f"{self._authorization_endpoint}?{urlencode(params)}"
+
+    async def exchange_code(
+        self,
+        code: str,
+        redirect_uri: str,
+    ) -> ExchangeResult:
+        """
+        Exchange the Ory auth code for a user ID (and tokens).
+        """
+        data = {
+            "grant_type": "authorization_code",
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                self._token_endpoint,
+                data=data,
+            ) as response:
+                response.raise_for_status()
+                token_response = await response.json()
+
+            decoded = _decoded_id_token(token_response.get("id_token"))
+            user_id = decoded.get("sub") if decoded is not None else None
+            # The ID token carries the requested identity claims (we
+            # requested the scopes they need); surface whichever are
+            # present, under their presented names.
+            claims = self._presented_claims(decoded or {})
+
+        if user_id is None:
+            raise ValueError(
+                "Ory did not return an ID token with a 'sub' claim; "
+                "cannot resolve the user's identity."
+            )
+        return ExchangeResult(
+            user_id=UserId(user_id),
+            tokens=self._tokens_from_response(token_response),
+            claims=claims,
+        )
+
+    def _tokens_from_response(
+        self,
+        token_response: dict,
+    ) -> Optional[OAuthTokens]:
+        """Build an `OAuthTokens` from an Ory token endpoint response,
+        or `None` when token storage isn't enabled or no access token
+        came back. Ory only returns a `refresh_token` when
+        `offline_access` was requested (see `authorization_url`).
         """
         if not self._store_tokens:
             return None

--- a/reboot/aio/auth/oauth_providers.py
+++ b/reboot/aio/auth/oauth_providers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import aiohttp
 import hashlib
 import hmac
+import json
 import jwt
 import os
 from abc import ABC, abstractmethod
@@ -14,18 +15,40 @@ from jinja2 import Template
 from log.log import get_logger, log_at_most_once_per
 from rbt.std.oauth.v1.oauth_rbt import OAuthTokens
 from reboot.aio.exceptions import InputError
-from reboot.aio.http import PythonWebFramework
+from reboot.aio.external import ExternalContext
+from reboot.aio.http import PythonWebFramework, external_context
 from reboot.crypto import root_keys
 from reboot.run_environments import running_rbt_dev
 from starlette.requests import Request
-from starlette.responses import HTMLResponse
-from typing import Any, Mapping, NewType, Optional, Sequence
+from starlette.responses import HTMLResponse, JSONResponse, Response
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Mapping,
+    NewType,
+    Optional,
+    Sequence,
+)
 from ulid import ULID
 from urllib.parse import urlencode, urlparse, urlunparse
 
 logger = get_logger(__name__)
 
 UserId = NewType("UserId", str)
+
+# Delivers a user's verified identity claims to their state if it
+# already exists, never constructing it (see a servicer's
+# `_set_claims_if_exists`). Providers that mount routes firing
+# outside a sign-in — e.g. an identity provider webhook, which fires
+# for every identity in the provider — deliver through this, so a
+# fired-for identity that never signed into this application is never
+# materialized. Receives an app-internal `ExternalContext`, the id of
+# the user whose claims these are, and the verified claims.
+ClaimsChanged = Callable[
+    [ExternalContext, str, Mapping[str, Any]],
+    Awaitable[None],
+]
 
 _DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 24 * 60 * 60  # 24 hours.
 
@@ -160,6 +183,9 @@ class OAuthProvider(ABC):
         # source claim name to presented claim name; `None` when no
         # claims were requested.
         self._claims = self._normalized_claims(claims)
+        # The application's set-claims-if-exists entrypoint; see
+        # `use_claims_changed`.
+        self._claims_changed: Optional[ClaimsChanged] = None
 
     def _normalized_claims(
         self,
@@ -256,6 +282,18 @@ class OAuthProvider(ABC):
             for name, presented in self._claims.items()
             if source.get(name) is not None
         }
+
+    def use_claims_changed(
+        self,
+        claims_changed: ClaimsChanged,
+    ) -> None:
+        """Wire the application's set-claims-if-exists entrypoint into
+        this provider, so provider-mounted routes (e.g. a webhook) can
+        deliver a user's verified identity claims outside a sign-in —
+        to a user whose state already exists, never materializing one.
+        Called by the OAuth server before `mount_routes`.
+        """
+        self._claims_changed = claims_changed
 
     @abstractmethod
     def authorization_url(
@@ -964,6 +1002,16 @@ class Auth0(RegisteredOAuthProvider):
         )
 
 
+# Path of the `Ory` settings-flow webhook route. Prefixed with
+# `__/oauth/` to match the other OAuth endpoints and to avoid
+# colliding with developer-specified routes.
+_ORY_WEBHOOK_PATH = "/__/oauth/ory/webhook"
+
+# Header carrying the webhook's shared secret, matching the `auth`
+# configuration of the Ory Action (see `Ory`'s docstring).
+_ORY_WEBHOOK_KEY_HEADER = "x-ory-webhook-key"
+
+
 class Ory(RegisteredOAuthProvider):
     """
     Ory OAuth provider (OpenID Connect).
@@ -984,6 +1032,43 @@ class Ory(RegisteredOAuthProvider):
     (`email` for the email claims, `profile` for the rest) are
     requested automatically — make sure the OAuth2 client is allowed
     to request them.
+
+    Sign-ins deliver claims; a webhook keeps them fresh in between.
+    A user who changes their email in an Ory settings flow would
+    otherwise only propagate that change to the application at their
+    next sign-in. Pass a `webhook_secret` (with `claims=`, since
+    delivering claims is all the webhook does) and this provider
+    exposes `POST /__/oauth/ory/webhook`; configure an Ory Action to
+    call it after the settings flow and identity changes propagate
+    immediately — but only for users who have already signed into
+    this application (the webhook never materializes a `User` for an
+    identity that has not). Ory documents how to configure such an
+    Action; see
+    https://www.ory.com/docs/guides/integrate-with-ory-cloud-through-webhooks.
+    In the Ory project config, under `selfservice.flows.settings.after`:
+
+    ```yaml
+    hooks:
+      - hook: web_hook
+        config:
+          url: https://<your-app-base-url>/__/oauth/ory/webhook
+          method: POST
+          # Jsonnet: function(ctx) { identity: ctx.identity }
+          body: base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ==
+          auth:
+            type: api_key
+            config:
+              name: x-ory-webhook-key
+              value: <webhook_secret>
+              in: header
+    ```
+
+    The webhook expects a JSON body shaped like
+    `{"identity": {"id": ..., "traits": {...}, ...}}` (which the
+    Jsonnet above produces) and maps the identity onto the same
+    claims shape sign-in delivers. Identity edits made through Ory's
+    *admin* API do not run flow-scoped actions, so those still only
+    propagate at the user's next sign-in.
     """
 
     # `openid` is the minimum OIDC scope; yields an ID token with the
@@ -1027,6 +1112,12 @@ class Ory(RegisteredOAuthProvider):
         scopes: Optional[list[str]] = None,
         store_tokens: bool = False,
         claims: Optional[Sequence[str] | Mapping[str, str]] = None,
+        # Shared secret authenticating calls to the settings-flow
+        # webhook (see the class docstring); the webhook route is
+        # only mounted when one is set. Inject it the same way as
+        # `client_secret` — from a secret store / environment secret,
+        # never a hard-coded literal.
+        webhook_secret: Optional[str] = None,
     ):
         super().__init__(
             client_id=client_id,
@@ -1035,7 +1126,22 @@ class Ory(RegisteredOAuthProvider):
             store_tokens=store_tokens,
             claims=claims,
         )
+        if webhook_secret is not None and self._claims is None:
+            # Delivering identity claims is all the webhook does, so
+            # a webhook configured without any claims to deliver is a
+            # contradiction; fail fast rather than mounting a route
+            # that could never deliver anything.
+            raise InputError(
+                reason=(
+                    "`Ory` got a `webhook_secret=` but no `claims=`: "
+                    "the settings-flow webhook exists to deliver "
+                    "identity claims, so pass `claims=` (e.g. "
+                    "`claims=['email']`) or remove the "
+                    "`webhook_secret=`."
+                ),
+            )
         self._domain = _normalize_domain(domain)
+        self._webhook_secret = webhook_secret
 
     @property
     def _authorization_endpoint(self) -> str:
@@ -1057,6 +1163,153 @@ class Ory(RegisteredOAuthProvider):
             raise InputError(
                 reason="Ory requires a non-empty `domain`.",
             )
+        if self._webhook_secret is not None and not self._webhook_secret:
+            # An empty `webhook_secret` authenticates nobody, so it is
+            # a misconfiguration; the default `webhook_secret=None` is
+            # what leaves the settings-flow webhook unexposed.
+            raise InputError(
+                reason=(
+                    "Ory got an empty `webhook_secret`; pass the "
+                    "shared secret the Ory Action sends, or drop the "
+                    "`webhook_secret=` to not expose the "
+                    "settings-flow webhook at all."
+                ),
+            )
+
+    def mount_routes(self, http: PythonWebFramework.HTTP) -> None:
+        # The webhook route only exists when a shared secret was
+        # configured; without one there would be no way to
+        # authenticate Ory's calls.
+        if self._webhook_secret:
+            # The handler delivers claims through the app-internal-only
+            # set-claims-if-exists entrypoint, so it opts in to an
+            # app-internal context with `app_internal=True`. That's
+            # safe here because the handler authenticates the caller
+            # against the shared webhook secret before doing any
+            # app-internal work.
+            http.post(_ORY_WEBHOOK_PATH, app_internal=True)(self._webhook)
+
+    def _claims_from_identity(
+        self,
+        identity: Mapping[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        """Map an Ory identity (as a webhook delivers it: `id`,
+        `traits`, `updated_at`, `verifiable_addresses`, ...) onto the
+        same claims shape the sign-in code exchange produces: the
+        requested claims, under their presented names; `None` when
+        this provider was constructed without `claims=`. Applies the
+        same identity-to-claims rules Ory's built-in mapping does (see
+        `_AVAILABLE_CLAIMS`), so both paths deliver the same claims
+        for the same identity."""
+        source = dict(identity.get("traits") or {})
+        # Kratos identity schemas may model `name` as a string trait
+        # or as a structured one; Ory maps a string to the `name`
+        # claim and an object to `given_name` / `family_name` off its
+        # `first` / `last` members.
+        name = source.pop("name", None)
+        if isinstance(name, str):
+            source["name"] = name
+        elif isinstance(name, Mapping):
+            for member, claim in (
+                ("first", "given_name"),
+                ("last", "family_name"),
+            ):
+                if name.get(member) is not None:
+                    source[claim] = name[member]
+        # `updated_at` is a top-level field of the identity rather
+        # than one of its traits.
+        if identity.get("updated_at") is not None:
+            source["updated_at"] = identity["updated_at"]
+        email = source.get("email")
+        if email is not None:
+            # Derive `email_verified` from the identity's verifiable
+            # addresses, like Ory's own OIDC claims mapping does.
+            for address in identity.get("verifiable_addresses") or []:
+                if (
+                    address.get("via") == "email" and
+                    address.get("value") == email
+                ):
+                    source["email_verified"] = bool(address.get("verified"))
+                    break
+        return self._presented_claims(source)
+
+    async def _webhook(self, request: Request) -> Response:
+        """POST /__/oauth/ory/webhook
+
+        Called by an Ory Action after a settings flow (see the class
+        docstring for the configuration), delivering the changed
+        identity's claims so they propagate without waiting for the
+        user's next sign-in.
+
+        Deliveries are last-write-wins with no event ordering: a
+        delayed Ory retry can transiently overwrite a newer change
+        until the next delivery or sign-in converges the state again.
+        """
+        # Invariant: the route is only mounted when a secret is
+        #            configured.
+        assert self._webhook_secret is not None
+        provided = request.headers.get(_ORY_WEBHOOK_KEY_HEADER, "")
+        if not hmac.compare_digest(
+            provided.encode(),
+            self._webhook_secret.encode(),
+        ):
+            return JSONResponse(
+                {"error": "unauthorized"},
+                status_code=401,
+            )
+
+        body = await request.body()
+        try:
+            payload = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            # A body that isn't valid UTF-8 raises `UnicodeDecodeError`
+            # rather than `JSONDecodeError`; both are malformed input,
+            # which is the caller's problem rather than ours.
+            return JSONResponse(
+                {"error": "invalid_json"},
+                status_code=400,
+            )
+        identity = (
+            payload.get("identity") if isinstance(payload, dict) else None
+        )
+        if not isinstance(identity, dict):
+            return JSONResponse(
+                {"error": "missing_identity"},
+                status_code=400,
+            )
+        identity_id = identity.get("id")
+        if not isinstance(identity_id, str) or not identity_id:
+            return JSONResponse(
+                {"error": "missing_identity_id"},
+                status_code=400,
+            )
+
+        if self._claims_changed is None:
+            # No claims consumer is wired up (e.g. the application
+            # has no auto-construct state types); acknowledge and
+            # drop.
+            return Response(status_code=204)
+
+        # Invariant: the constructor requires `claims=` whenever a
+        #            `webhook_secret=` is configured.
+        claims = self._claims_from_identity(identity)
+        assert claims is not None
+
+        # The route is `app_internal=True`, making this a trusted
+        # app-internal call — required, since claims ride the
+        # delivery. This delivers only to a `User` that already
+        # exists: an identity that never signed into this application
+        # is skipped (Ory webhooks fire for every identity in the
+        # project), and it converges on the delivered claims for one
+        # that has. Retries and replays are safe — `set_claims` is a
+        # full replace, idempotent by contract.
+        await self._claims_changed(
+            external_context(request),
+            UserId(identity_id),
+            claims,
+        )
+
+        return Response(status_code=204)
 
     def authorization_url(
         self,

--- a/reboot/aio/auth/oauth_server.py
+++ b/reboot/aio/auth/oauth_server.py
@@ -26,6 +26,7 @@ from reboot.aio.auth import (
 )
 from reboot.aio.auth.allowed_origins import is_allowed_origin
 from reboot.aio.auth.oauth_providers import (
+    ClaimsChanged,
     OAuthProvider,
     OAuthTokens,
     UserId,
@@ -322,6 +323,7 @@ class OAuthServer:
         authenticated: Optional[
             Callable[[ExternalContext, str, Optional[Mapping[str, Any]]],
                      Awaitable[None]]] = None,
+        claims_changed: Optional[ClaimsChanged] = None,
         allowed_origins: Optional[Sequence[str]] = None,
     ):
         """`authenticated`, if given, runs right after each fresh
@@ -333,6 +335,13 @@ class OAuthServer:
         `claims=`; `None` on refreshes and other mints that don't
         consult the provider). It must be idempotent and inexpensive —
         it can run on every mint for the same user.
+
+        `claims_changed`, if given, is wired into the provider
+        (via `use_claims_changed`) so that provider-mounted
+        routes firing outside a sign-in — e.g. an identity provider
+        webhook — can deliver claims to a user whose state already
+        exists, without ever materializing state for an identity that
+        never signed in.
 
         `allowed_origins` is `Application(allowed_origins=...)`'s
         explicit allow-list (with `None` meaning it, like `oauth=`,
@@ -347,6 +356,7 @@ class OAuthServer:
             auto_construct_state_type_full_names or []
         )
         self._authenticated = authenticated
+        self._claims_changed = claims_changed
         self._access_token_ttl_seconds = provider.access_token_ttl_seconds
         # Derived from the Reboot-managed cryptographic root keys; raises
         # if `REBOOT_CRYPTO_ROOT_KEYS` is unset/malformed (fail fast at
@@ -424,7 +434,12 @@ class OAuthServer:
         http.post(_SIGNOUT_PATH)(self.signout)
         http.get(_WHOAMI_PATH)(self.whoami)
 
-        # Let the provider register any additional routes it needs.
+        # Let the provider register any additional routes it needs,
+        # wiring in the set-claims-if-exists entrypoint first so those
+        # routes (e.g. an identity provider webhook) can deliver claims
+        # to existing users outside a sign-in.
+        if self._claims_changed is not None:
+            self._provider.use_claims_changed(self._claims_changed)
         self._provider.mount_routes(http)
 
     # ---- Helpers ----

--- a/reboot/aio/servicers.py
+++ b/reboot/aio/servicers.py
@@ -81,6 +81,25 @@ class Servicer(ABC):
         """
         pass
 
+    # Naming: has a leading underscore to ensure it doesn't collide with
+    # customer-API-defined methods; those can't use leading underscores.
+    @staticmethod
+    async def _set_claims_if_exists(
+        context: ExternalContext,
+        state_id: str,
+        claims: Mapping[str, Any],
+    ) -> None:
+        """
+        Deliver a user's verified identity claims to their state —
+        but only if it already exists; never construct it. For
+        identity changes that arrive outside a sign-in (e.g. an
+        identity provider webhook), where materializing state for an
+        identity that never signed in would be wrong.
+
+        Overridden by generated code for auto-constructable state types.
+        """
+        pass
+
 
 class ConfigServicer(config_mode_pb2_grpc.ConfigServicer):
 

--- a/reboot/plugin/skills/chat-app/references/auth-custom-oauth-provider.md
+++ b/reboot/plugin/skills/chat-app/references/auth-custom-oauth-provider.md
@@ -15,7 +15,9 @@ Reach here **last**. The order of preference for
 2. **`Auth0`** when you need several login methods behind one provider,
    or user management beyond a bare user id (profiles, password resets,
    MFA, …) — Auth0 brokers most IdPs, including enterprise SSO.
-3. **A custom provider** only when neither works: a self-hosted
+   **`Ory`** when the users live in an Ory Network project or
+   self-hosted Ory deployment.
+3. **A custom provider** only when none of those work: a self-hosted
    Keycloak, an internal SSO you can't put Auth0 in front of, an OAuth
    service Auth0 can't broker.
 
@@ -46,6 +48,22 @@ minting the app's own access tokens, populating
   a plain-OAuth IdP by calling its user-info API with the access token
   (that's what `GitHub` does). Raising any exception here is safe — the
   server logs it and turns it into a graceful `access_denied` redirect.
+  Also fill `ExchangeResult.claims` with the user's verified identity
+  claims if your IdP can supply any: declare the claims it can
+  deliver — and the OAuth scope each one needs — in the class-level
+  `_AVAILABLE_CLAIMS` mapping, accept `claims=` at construction
+  (pass it through to `super().__init__`, which rejects unavailable
+  claims and derives the needed scopes), and pass the decoded ID
+  token (or userinfo response) through
+  `self._presented_claims(...)`, which keeps only the claims the
+  developer requested — under their presented names — so ephemeral
+  protocol claims (`exp`, `nonce`, …) and IdP-specific claim names
+  never leak out of the provider. Claims must come from a verified
+  source only: an ID token straight from the token endpoint over
+  TLS, or the userinfo endpoint over TLS. They are delivered to the
+  auto-constructed `User` type's `set_claims` method on every
+  sign-in; when the developer requested no claims,
+  `_presented_claims` returns `None` and nothing is ever delivered.
 
 > **The user id must be stable.** Whatever `exchange_code` returns
 > becomes `context.auth.user_id` and the key of all user-keyed state —
@@ -62,10 +80,24 @@ Optional hooks:
   for the current environment, so a misconfigured `prod=` arm fails at
   startup, not mid-sign-in. `RegisteredOAuthProvider` already checks
   `client_id` / `client_secret`; override to check your extras (call
-  `super().validate()` first — see `Auth0._normalize_domain` /
-  `Auth0.validate` for the shape).
+  `super().validate()` first — see `Auth0.validate` for the shape).
 - **`mount_routes(http)`** — register provider-specific HTTP routes,
-  rarely needed (`Development` uses it for its login page).
+  rarely needed (`Development` uses it for its login page; `Ory` uses
+  it for a settings-flow webhook). A route that delivers identity
+  changes from the IdP between sign-ins can call
+  `self._set_claims_if_exists(...)` — the application's
+  set-claims-if-exists entrypoint, wired in by the OAuth server via
+  `use_set_claims_if_exists` before `mount_routes` runs — but must
+  authenticate its caller first (a shared secret, a signature):
+  claims assert a user's identity, so the route is a
+  who-can-impersonate-users boundary. It delivers only to a `User`
+  that already exists, never materializing one for an identity that
+  never signed in (webhooks fire instance-wide). Deliveries may run
+  repeatedly (`set_claims` is a full replace, idempotent by
+  contract), so re-delivering the same change is harmless — but
+  ordering is last-write-wins: a delayed retry can transiently
+  overwrite a newer change until the next delivery or sign-in
+  converges the state again. See `Ory._webhook` for the model.
 - **`token_service_id`** — see "Supporting `store_tokens=True`" below.
 
 ## Model your provider on the shipped ones

--- a/reboot/plugin/skills/chat-app/references/auth-oauth-providers.md
+++ b/reboot/plugin/skills/chat-app/references/auth-oauth-providers.md
@@ -36,6 +36,7 @@ The **providers** you place in the `dev` / `prod` arms ship in
 | `Google(...)`   | `Google(client_id=..., client_secret=...)`            | Google account's OIDC `sub` claim                        | Production apps where users sign in with Google.                                                                                                               |
 | `GitHub(...)`   | `GitHub(client_id=..., client_secret=...)`            | GitHub user's numeric ID (as `str`)                      | Production apps where users sign in with GitHub.                                                                                                               |
 | `Auth0(...)`    | `Auth0(domain=..., client_id=..., client_secret=...)` | Auth0 OIDC `sub` (e.g. `google-oauth2\|108…`)            | Production apps that broker sign-in through Auth0 (Google, GitHub, password, SSO) behind one provider, or that need **user management** beyond a bare user id. |
+| `Ory(...)`      | `Ory(domain=..., client_id=..., client_secret=...)`   | Ory OIDC `sub` (the Kratos identity id)                  | Production apps whose users live in an Ory Network project or self-hosted Ory (Kratos + Hydra) deployment.                                                     |
 
 `Auth0` takes a `domain=` (your tenant, e.g. `your-tenant.us.auth0.com`)
 on top of the client credentials — all its endpoints live under that
@@ -47,6 +48,14 @@ upstream in Auth0, not in your code. Because the `sub` it issues encodes
 the upstream connection (`google-oauth2|…`, `auth0|…`, `github|…`), the
 namespace-permanence rule below still applies: changing which Auth0
 connections you offer can change users' `sub`s.
+
+`Ory` similarly takes a `domain=` (your project, e.g.
+`your-slug.projects.oryapis.com`) on top of the client credentials.
+Pass `claims=` (e.g. `claims=["email"]`) to have the identity
+delivered as verified identity claims on every sign-in; the scopes
+those claims need (`email` for the email claims, `profile` for the
+rest) are requested automatically, so allow them on the OAuth2
+client in the Ory Console.
 
 **Identity claims.** Signing in identifies the user; pass `claims=`
 at provider construction to also learn _about_ them: e.g.
@@ -256,6 +265,13 @@ we won't try to mirror here:
   `client_secret=`. Enable the upstream connections you want users to
   sign in through (Google, GitHub, username/password, SSO) under the
   application's Connections tab.
+- **Ory**: in the [Ory Console](https://www.ory.sh/docs/oauth2-oidc/authorization-code-flow),
+  create an **OAuth2 client** with the authorization-code grant and
+  the `openid` scope allowed (plus `email` / `profile` for any
+  `claims=` you request, and `offline_access` if you use it). The
+  project domain (e.g. `your-slug.projects.oryapis.com`), Client ID,
+  and Client Secret are what you pass as `domain=`, `client_id=`,
+  and `client_secret=`.
 
 For every provider, register the callback URL Reboot serves —
 `<your-app-base-url>/__/oauth/callback` (note the `/__/` prefix) — when
@@ -297,6 +313,9 @@ the provider, and providers don't share an ID space:
 - `GitHub` issues a numeric account ID.
 - `Auth0` issues its OIDC `sub`, which encodes the upstream connection
   (`google-oauth2|…`, `auth0|…`).
+- `Ory` issues its OIDC `sub` — the Kratos identity id of the user in
+  your Ory project (with the default, non-pairwise subject
+  configuration).
 - `Anonymous()` issues a fresh `anon-{ULID}` per flow.
 - `Development()` issues a `dev-{hash}` per fake identity.
 

--- a/reboot/plugin/skills/chat-app/references/auth-oauth-providers.md
+++ b/reboot/plugin/skills/chat-app/references/auth-oauth-providers.md
@@ -55,7 +55,16 @@ Pass `claims=` (e.g. `claims=["email"]`) to have the identity
 delivered as verified identity claims on every sign-in; the scopes
 those claims need (`email` for the email claims, `profile` for the
 rest) are requested automatically, so allow them on the OAuth2
-client in the Ory Console.
+client in the Ory Console. Optionally pass a
+`webhook_secret=` (it requires `claims=` — delivering claims is all
+the webhook does) and configure an Ory Action calling
+`POST /__/oauth/ory/webhook` after the settings flow (the `Ory`
+class docstring shows the exact configuration): a user's email
+change then propagates to the application immediately instead of at
+their next sign-in — for users who have already signed in here (the
+webhook never materializes a `User` for an identity that hasn't).
+Identity edits made through Ory's _admin_ API don't run flow-scoped
+actions, so those still propagate at the next sign-in.
 
 **Identity claims.** Signing in identifies the user; pass `claims=`
 at provider construction to also learn _about_ them: e.g.

--- a/reboot/templates/reboot.py.j2
+++ b/reboot/templates/reboot.py.j2
@@ -3138,9 +3138,23 @@ class {{ state.proto.name }}BaseServicer(IMPORT_reboot_aio_servicers.Servicer):
         # then, and `set_state(claims=FOO)` would have an effect again -
         # we want to converge on the most recently delivered claims.
         if claims is not None:
+{% if options.proto.pydantic %}
             await {{ state.proto.name }}.ref(state_id).always().{{ SET_CLAIMS_METHOD }}(
                 context, claims=claims
             )
+{% else %}
+            # This state's `{{ SET_CLAIMS_METHOD }}` request carries
+            # claims as a `map<string, google.protobuf.Value>`, but the
+            # framework delivers them as native Python values. A
+            # `Struct` wraps each native value in the `Value` the
+            # generated request expects, so we load the claims into one
+            # and hand its fields to `{{ SET_CLAIMS_METHOD }}`.
+            claims_struct = google.protobuf.struct_pb2.Struct()
+            claims_struct.update(claims)
+            await {{ state.proto.name }}.ref(state_id).always().{{ SET_CLAIMS_METHOD }}(
+                context, claims=dict(claims_struct.fields)
+            )
+{% endif %}
 
     @staticmethod
     async def _set_claims_if_exists(
@@ -3163,9 +3177,19 @@ class {{ state.proto.name }}BaseServicer(IMPORT_reboot_aio_servicers.Servicer):
         carries the current claims.
         """
         try:
+{% if options.proto.pydantic %}
             await {{ state.proto.name }}.ref(state_id).always().{{ SET_CLAIMS_METHOD }}(
                 context, claims=claims
             )
+{% else %}
+            # See `_authenticated` for why the claims are loaded into
+            # a `Struct` here.
+            claims_struct = google.protobuf.struct_pb2.Struct()
+            claims_struct.update(claims)
+            await {{ state.proto.name }}.ref(state_id).always().{{ SET_CLAIMS_METHOD }}(
+                context, claims=dict(claims_struct.fields)
+            )
+{% endif %}
         except {{ state.proto.name }}.{{ SET_CLAIMS_PROTO_METHOD }}Aborted as aborted:
             # A `{{ SET_CLAIMS_METHOD }}` on a state that was never
             # constructed aborts with `StateNotConstructed` (and logs

--- a/reboot/templates/reboot.py.j2
+++ b/reboot/templates/reboot.py.j2
@@ -3106,16 +3106,29 @@ class {{ state.proto.name }}BaseServicer(IMPORT_reboot_aio_servicers.Servicer):
         # e.g. a per-user state on every sign-in. We derive a
         # deterministic idempotency key from the state ID so that the
         # construct is a NOOP once the state exists (even across
-        # different contexts). We prefer this over catching the
-        # `StateAlreadyConstructed` error that would otherwise result,
-        # since that logs an `ERROR` to user-visible logs.
+        # different contexts), without the `ERROR` that catching
+        # `StateAlreadyConstructed` alone would log on every sign-in.
         idempotency_key = IMPORT_uuid.uuid5(
             IMPORT_uuid.NAMESPACE_URL,
             f"urn:dev.reboot:auto-construct:{{ state.proto.name }}:{state_id}",
         )
-        await {{ state.proto.name }}.idempotently(
-            key=idempotency_key,
-        ).{{ AUTO_CONSTRUCT_METHOD }}(context, state_id)
+        try:
+            await {{ state.proto.name }}.idempotently(
+                key=idempotency_key,
+            ).{{ AUTO_CONSTRUCT_METHOD }}(context, state_id)
+        except {{ state.proto.name }}.{{ AUTO_CONSTRUCT_PROTO_METHOD }}Aborted as aborted:
+            # The state may predate auto-construction: one constructed
+            # through some explicit flow before the application adopted
+            # `auto_construct` (or before this user first signed in
+            # through OAuth) aborts with `StateAlreadyConstructed`,
+            # since the idempotency key only dedupes *this* call site.
+            # The state exists, which is all this call is for, so
+            # swallow it; anything else is a real error and propagates.
+            if not isinstance(
+                aborted.error,
+                IMPORT_rbt_v1alpha1.errors_pb2.StateAlreadyConstructed,
+            ):
+                raise
         # The two calls are deliberately sequential rather than wrapped
         # in one transaction: an idempotent construct followed by a
         # full-replace `{{ SET_CLAIMS_METHOD }}` compose convergently.

--- a/reboot/templates/reboot.py.j2
+++ b/reboot/templates/reboot.py.j2
@@ -3128,6 +3128,43 @@ class {{ state.proto.name }}BaseServicer(IMPORT_reboot_aio_servicers.Servicer):
             await {{ state.proto.name }}.ref(state_id).always().{{ SET_CLAIMS_METHOD }}(
                 context, claims=claims
             )
+
+    @staticmethod
+    async def _set_claims_if_exists(
+        context: IMPORT_reboot_aio_external.ExternalContext,
+        state_id: str,
+        claims: IMPORT_typing.Mapping[str, IMPORT_typing.Any],
+    ) -> None:
+        """Deliver a user's verified identity claims to their
+        `{{ state.proto.name }}` — but ONLY if it already exists;
+        never construct it. This is for identity changes that arrive
+        outside a sign-in (e.g. an identity provider webhook, which
+        fires for every identity in the provider, most of which may
+        never have signed into this application): materializing a
+        `{{ state.proto.name }}` for an identity that never signed in
+        would be wrong.
+
+        Racing a user's very first sign-in is safe: if the sign-in
+        constructs the state first, this delivery lands; if it has
+        not yet, this skips and the sign-in's own claims delivery
+        carries the current claims.
+        """
+        try:
+            await {{ state.proto.name }}.ref(state_id).always().{{ SET_CLAIMS_METHOD }}(
+                context, claims=claims
+            )
+        except {{ state.proto.name }}.{{ SET_CLAIMS_PROTO_METHOD }}Aborted as aborted:
+            # A `{{ SET_CLAIMS_METHOD }}` on a state that was never
+            # constructed aborts with `StateNotConstructed` (and logs
+            # one `WARNING`); that is exactly the "identity never
+            # signed in here" case, so swallow it. Any other abort is
+            # a real error and propagates.
+            if isinstance(
+                aborted.error,
+                IMPORT_rbt_v1alpha1.errors_pb2.StateNotConstructed,
+            ):
+                return
+            raise
 {% endif %}
 
     def ref(

--- a/tests/reboot/aio/auth/oauth_providers_test.py
+++ b/tests/reboot/aio/auth/oauth_providers_test.py
@@ -21,6 +21,7 @@ from reboot.aio.auth.oauth_providers import (
     Google,
     OAuthProvider,
     OAuthProviderByEnvironment,
+    Ory,
     RegisteredOAuthProvider,
     UserId,
 )
@@ -1563,6 +1564,84 @@ class Auth0DomainTest(unittest.TestCase):
         self.assertTrue(url.startswith("https://tenant.auth0.com/authorize?"))
 
 
+class OryValidateTest(unittest.TestCase):
+    """
+    Same shape as `Auth0ValidateTest`: each missing field names itself
+    and (for the credentials) the `Ory` class, so a developer reading
+    startup logs knows which env var to set.
+    """
+
+    def test_none_client_id_message_names_ory(self):
+        provider = Ory(
+            domain="slug.projects.oryapis.com",
+            client_id=None,
+            client_secret="secret",
+        )
+        with self.assertRaises(InputError) as context:
+            provider.validate()
+        self.assertIn("Ory", str(context.exception))
+        self.assertIn("`client_id`", str(context.exception))
+
+    def test_none_client_secret_message_names_ory(self):
+        provider = Ory(
+            domain="slug.projects.oryapis.com",
+            client_id="id",
+            client_secret=None,
+        )
+        with self.assertRaises(InputError) as context:
+            provider.validate()
+        self.assertIn("Ory", str(context.exception))
+        self.assertIn("`client_secret`", str(context.exception))
+
+    def test_missing_domain_rejected(self):
+        provider = Ory(
+            domain=None,
+            client_id="id",
+            client_secret="secret",
+        )
+        with self.assertRaises(InputError) as context:
+            provider.validate()
+        self.assertIn("Ory", str(context.exception))
+        self.assertIn("`domain`", str(context.exception))
+
+    def test_all_supplied_passes(self):
+        Ory(
+            domain="slug.projects.oryapis.com",
+            client_id="id",
+            client_secret="secret",
+        ).validate()
+
+
+class OryDomainTest(unittest.TestCase):
+    """The `domain` is accepted bare or as a full URL, and the
+    authorization endpoint is derived from it under the project —
+    that's what lets a developer paste either form from the Ory
+    Console."""
+
+    def test_bare_domain_builds_project_authorize_url(self):
+        url = Ory(
+            domain="slug.projects.oryapis.com",
+            client_id="id",
+            client_secret="s",
+        ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+        self.assertTrue(
+            url.startswith("https://slug.projects.oryapis.com/oauth2/auth?")
+        )
+
+    def test_full_url_domain_is_normalized(self):
+        # A pasted `https://slug.projects.oryapis.com/` must resolve
+        # to the same endpoint as the bare host, not a doubled-up
+        # scheme.
+        url = Ory(
+            domain="https://slug.projects.oryapis.com/",
+            client_id="id",
+            client_secret="s",
+        ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+        self.assertTrue(
+            url.startswith("https://slug.projects.oryapis.com/oauth2/auth?")
+        )
+
+
 class RequestedClaimsTest(unittest.TestCase):
     """The `claims=` a provider is constructed with decides exactly
     what `_presented_claims` lets out of a decoded ID token (or
@@ -1889,6 +1968,90 @@ class ScopeTest(unittest.TestCase):
         storing = _scope_param(
             Auth0(
                 domain="tenant.auth0.com",
+                client_id="id",
+                client_secret="s",
+                store_tokens=True,
+            ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+        )
+        self.assertIn("offline_access", storing)
+
+    def test_ory_defaults_to_openid_only(self):
+        url = Ory(
+            domain="slug.projects.oryapis.com",
+            client_id="id",
+            client_secret="s",
+        ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+        self.assertEqual(_scope_param(url), ["openid"])
+
+    def test_ory_derives_scopes_from_requested_claims(self):
+        # Requesting the email identity claims requests the `email`
+        # scope that makes Ory map the identity's email traits into
+        # the ID token; `name` similarly brings in `profile`.
+        url = Ory(
+            domain="slug.projects.oryapis.com",
+            client_id="id",
+            client_secret="s",
+            claims=["email", "email_verified", "name"],
+        ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+        self.assertEqual(_scope_param(url), ["openid", "email", "profile"])
+
+    def test_ory_accepts_every_claim_its_built_in_mapping_emits(self):
+        # `_AVAILABLE_CLAIMS` is a hard allow-list — an application
+        # cannot request a claim missing from it — so it holds every
+        # claim Ory's built-in mapping emits, each bringing in the
+        # scope Ory needs to emit it.
+        for claim, scope in (
+            ("email", "email"),
+            ("email_verified", "email"),
+            ("name", "profile"),
+            ("given_name", "profile"),
+            ("family_name", "profile"),
+            ("username", "profile"),
+            ("website", "profile"),
+            ("updated_at", "profile"),
+        ):
+            url = Ory(
+                domain="slug.projects.oryapis.com",
+                client_id="id",
+                client_secret="s",
+                claims=[claim],
+            ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+            self.assertEqual(
+                _scope_param(url),
+                ["openid", scope],
+                msg=f"claim {claim!r}",
+            )
+
+    def test_ory_adds_extra_scopes_after_base(self):
+        url = Ory(
+            domain="slug.projects.oryapis.com",
+            client_id="id",
+            client_secret="s",
+            scopes=["profile", "email"],
+            claims=["email"],
+        ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+        scopes = _scope_param(url)
+        self.assertEqual(scopes[0], "openid")
+        self.assertIn("profile", scopes)
+        # The claim-derived `email` and the explicitly requested one
+        # don't duplicate.
+        self.assertEqual(scopes.count("email"), 1)
+
+    def test_ory_store_tokens_requests_offline_access(self):
+        # Ory issues a refresh token only when `offline_access` is in
+        # the requested scopes (like Auth0); we add it only when
+        # storing tokens.
+        plain = _scope_param(
+            Ory(
+                domain="slug.projects.oryapis.com",
+                client_id="id",
+                client_secret="s",
+            ).authorization_url(state="x", redirect_uri="http://localhost/cb")
+        )
+        self.assertNotIn("offline_access", plain)
+        storing = _scope_param(
+            Ory(
+                domain="slug.projects.oryapis.com",
                 client_id="id",
                 client_secret="s",
                 store_tokens=True,

--- a/tests/reboot/aio/auth/oauth_providers_test.py
+++ b/tests/reboot/aio/auth/oauth_providers_test.py
@@ -11,6 +11,7 @@ import unittest
 from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 from rbt.std.oauth.v1.oauth_rbt import OAuthTokenManager, OAuthTokens
+from reboot.aio.aborted import Aborted
 from reboot.aio.applications import Application
 from reboot.aio.auth.oauth_providers import (
     Anonymous,
@@ -1640,6 +1641,389 @@ class OryDomainTest(unittest.TestCase):
         self.assertTrue(
             url.startswith("https://slug.projects.oryapis.com/oauth2/auth?")
         )
+
+
+def _ory(**kwargs: Any) -> Ory:
+    """An `Ory` with throwaway credentials, for tests that only
+    exercise claims handling."""
+    return Ory(
+        domain="slug.projects.oryapis.com",
+        client_id="id",
+        client_secret="secret",
+        **kwargs,
+    )
+
+
+class OryClaimsFromIdentityTest(unittest.TestCase):
+    """`Ory._claims_from_identity` maps a webhook's identity payload
+    onto the same claims shape the sign-in code exchange produces —
+    the requested claims, under their presented names — so both paths
+    deliver consistently."""
+
+    _ALL_CLAIMS = [
+        "email",
+        "email_verified",
+        "name",
+        "given_name",
+        "family_name",
+        "username",
+        "website",
+        "updated_at",
+    ]
+
+    def test_maps_email_and_derives_email_verified(self):
+        self.assertEqual(
+            _ory(claims=self._ALL_CLAIMS)._claims_from_identity(
+                {
+                    "id":
+                        "identity-1",
+                    "traits": {
+                        "email": "jane@example.com"
+                    },
+                    "verifiable_addresses":
+                        [
+                            {
+                                "via": "email",
+                                "value": "other@example.com",
+                                "verified": True,
+                            },
+                            {
+                                "via": "email",
+                                "value": "jane@example.com",
+                                "verified": False,
+                            },
+                        ],
+                }
+            ),
+            {
+                "email": "jane@example.com",
+                "email_verified": False
+            },
+        )
+
+    def test_without_verifiable_addresses_no_email_verified(self):
+        self.assertEqual(
+            _ory(claims=self._ALL_CLAIMS)._claims_from_identity(
+                {
+                    "id": "identity-1",
+                    "traits": {
+                        "email": "jane@example.com"
+                    },
+                }
+            ),
+            {"email": "jane@example.com"},
+        )
+
+    def test_structured_name_trait_yields_given_and_family_name(self):
+        # Kratos identity schemas may model `name` as a structured
+        # trait; Ory maps such a `name` to `given_name` /
+        # `family_name`, and the OIDC `name` claim is a string, so the
+        # webhook must derive the same two rather than deliver the
+        # object.
+        claims = _ory(claims=self._ALL_CLAIMS)._claims_from_identity(
+            {
+                "id": "identity-1",
+                "traits":
+                    {
+                        "email": "jane@example.com",
+                        "name": {
+                            "first": "Jane",
+                            "last": "Doe",
+                        },
+                    },
+            }
+        )
+        self.assertEqual(
+            claims,
+            {
+                "email": "jane@example.com",
+                "given_name": "Jane",
+                "family_name": "Doe",
+            },
+        )
+        assert claims is not None  # Narrow for the type checker.
+        self.assertNotIn("name", claims)
+
+    def test_string_name_trait_is_kept(self):
+        self.assertEqual(
+            _ory(claims=self._ALL_CLAIMS)._claims_from_identity(
+                {
+                    "id": "identity-1",
+                    "traits": {
+                        "name": "Jane Doe"
+                    },
+                }
+            ),
+            {"name": "Jane Doe"},
+        )
+
+    def test_updated_at_comes_from_the_top_level_identity_field(self):
+        # Ory sources the `updated_at` claim from the identity's own
+        # `updated_at`, which sits alongside `traits` rather than
+        # inside it.
+        self.assertEqual(
+            _ory(claims=self._ALL_CLAIMS)._claims_from_identity(
+                {
+                    "id": "identity-1",
+                    "updated_at": "2026-07-21T12:00:00.000000Z",
+                    "traits": {
+                        "name": "Jane Doe"
+                    },
+                }
+            ),
+            {
+                "name": "Jane Doe",
+                "updated_at": "2026-07-21T12:00:00.000000Z",
+            },
+        )
+
+    def test_username_and_website_traits_pass_through(self):
+        # Ory sources these two straight from the identity's traits,
+        # so the webhook delivers them as they come.
+        self.assertEqual(
+            _ory(claims=self._ALL_CLAIMS)._claims_from_identity(
+                {
+                    "id": "identity-1",
+                    "traits":
+                        {
+                            "username": "jane",
+                            "website": "https://jane.example",
+                        },
+                }
+            ),
+            {
+                "username": "jane",
+                "website": "https://jane.example",
+            },
+        )
+
+    def test_only_requested_claims_under_presented_names(self):
+        # The webhook honors the same `claims=` request the sign-in
+        # exchange honors: unrequested traits stay inside the
+        # provider, and a mapped claim is delivered under its
+        # presented name.
+        self.assertEqual(
+            _ory(
+                claims={
+                    "email": "verified-email"
+                },
+            )._claims_from_identity(
+                {
+                    "id": "identity-1",
+                    "traits":
+                        {
+                            "email": "jane@example.com",
+                            "name": "Jane Doe",
+                        },
+                }
+            ),
+            {"verified-email": "jane@example.com"},
+        )
+
+
+_ORY_WEBHOOK_PATH = "/__/oauth/ory/webhook"
+
+_ORY_WEBHOOK_KEY_HEADER = "x-ory-webhook-key"
+
+_ORY_WEBHOOK_SECRET = "webhook-s3cret"
+
+
+class OryWebhookSecretRequiresClaimsTest(unittest.TestCase):
+
+    def test_webhook_secret_without_claims_rejected(self):
+        # Delivering identity claims is all the webhook does, so a
+        # `webhook_secret=` with no `claims=` to deliver is a
+        # configuration contradiction, rejected at construction.
+        with self.assertRaises(InputError) as context:
+            _ory(webhook_secret=_ORY_WEBHOOK_SECRET)
+        self.assertIn("`claims=`", str(context.exception))
+
+    def test_webhook_secret_with_claims_accepted(self):
+        _ory(
+            claims=["email"],
+            webhook_secret=_ORY_WEBHOOK_SECRET,
+        )
+
+    def test_empty_webhook_secret_rejected(self):
+        # An empty secret reads as "configured" while authenticating
+        # nobody, so `validate()` calls it out rather than letting the
+        # webhook quietly stay unexposed.
+        provider = _ory(claims=["email"], webhook_secret="")
+        with self.assertRaises(InputError) as context:
+            provider.validate()
+        self.assertIn("Ory", str(context.exception))
+        self.assertIn("`webhook_secret`", str(context.exception))
+
+
+class OryWebhookTest(unittest.IsolatedAsyncioTestCase):
+    """The Ory settings-flow webhook propagates identity changes
+    between sign-ins — but only for users who have already signed into
+    this application. An authenticated call for an existing `User`
+    reaches `set_claims`, so a changed email refreshes immediately
+    rather than at the user's next sign-in; a call for an identity
+    that never signed in here is a NOOP, never materializing a
+    `User`."""
+
+    async def asyncSetUp(self):
+        self.rbt = Reboot()
+        await self.rbt.start()
+
+    async def asyncTearDown(self):
+        await self.rbt.stop()
+
+    async def _up(self, webhook_secret: Optional[str]) -> None:
+        await self.rbt.up(
+            Application(
+                servicers=[
+                    AutoConstructUserServicer,
+                    AutoConstructProfileServicer,
+                ],
+                oauth=OAuthProviderForTest(
+                    Ory(
+                        domain="slug.projects.oryapis.com",
+                        client_id="id",
+                        client_secret="secret",
+                        claims=["email", "email_verified"],
+                        webhook_secret=webhook_secret,
+                    )
+                ),
+            )
+        )
+        self.webhook_url = self.rbt.http_localhost_url(_ORY_WEBHOOK_PATH)
+        # An app-internal context for reading back the delivered
+        # state.
+        self.context = self.rbt.create_external_context(
+            name=f"internal-{self.id()}",
+            app_internal=True,
+        )
+
+    async def _sign_in(self, user_id: str, email: str) -> None:
+        """Sign `user_id` in with the given email, constructing their
+        `User` and delivering the initial claims the way a real
+        sign-in does."""
+        await self.rbt.make_valid_oauth_access_token(
+            user_id=user_id,
+            claims={"email": email},
+        )
+
+    def _payload(self, identity_id: str, email: str) -> dict:
+        """A webhook body of the shape the documented Ory Action
+        configuration (`{ identity: ctx.identity }`) produces."""
+        return {
+            "identity":
+                {
+                    "id":
+                        identity_id,
+                    "traits": {
+                        "email": email,
+                    },
+                    "verifiable_addresses":
+                        [{
+                            "via": "email",
+                            "value": email,
+                            "verified": True,
+                        },],
+                },
+        }
+
+    async def _post(
+        self,
+        payload: dict,
+        secret: Optional[str] = _ORY_WEBHOOK_SECRET,
+    ) -> httpx.Response:
+        headers = {}
+        if secret is not None:
+            headers[_ORY_WEBHOOK_KEY_HEADER] = secret
+        async with httpx.AsyncClient(
+            timeout=_HTTP_TIMEOUT_SECONDS,
+        ) as client:
+            return await client.post(
+                self.webhook_url,
+                json=payload,
+                headers=headers,
+            )
+
+    async def test_unauthenticated_webhook_is_rejected(self):
+        await self._up(webhook_secret=_ORY_WEBHOOK_SECRET)
+        await self._sign_in("identity-1", "jane@example.com")
+
+        missing = await self._post(
+            self._payload("identity-1", "changed@example.com"),
+            secret=None,
+        )
+        self.assertEqual(missing.status_code, 401)
+
+        wrong = await self._post(
+            self._payload("identity-1", "changed@example.com"),
+            secret="not-the-secret",
+        )
+        self.assertEqual(wrong.status_code, 401)
+
+        # Neither call delivered anything: the email is unchanged.
+        user = await AutoConstructUser.ref("identity-1").get(self.context)
+        self.assertEqual(user.email, "jane@example.com")
+
+    async def test_webhook_without_secret_is_not_mounted(self):
+        # Without a shared secret there is no way to authenticate
+        # Ory's calls, so the route must not exist at all.
+        await self._up(webhook_secret=None)
+
+        response = await self._post(
+            self._payload("identity-1", "jane@example.com"),
+        )
+        self.assertEqual(response.status_code, 404)
+
+    async def test_malformed_body_is_a_bad_request(self):
+        # An authenticated call whose body we cannot parse is the
+        # caller's problem: it must read as a 400, including for a
+        # body that is not even valid UTF-8.
+        await self._up(webhook_secret=_ORY_WEBHOOK_SECRET)
+
+        async with httpx.AsyncClient(
+            timeout=_HTTP_TIMEOUT_SECONDS,
+        ) as client:
+            for body in (b"not json at all", b'{"identity": "\xff"}'):
+                response = await client.post(
+                    self.webhook_url,
+                    content=body,
+                    headers={
+                        _ORY_WEBHOOK_KEY_HEADER: _ORY_WEBHOOK_SECRET,
+                    },
+                )
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.json()["error"], "invalid_json")
+
+    async def test_webhook_for_unknown_identity_is_a_noop(self):
+        # Ory webhooks fire for every identity in the project; one for
+        # an identity that never signed into this application must not
+        # materialize a `User` for them.
+        await self._up(webhook_secret=_ORY_WEBHOOK_SECRET)
+
+        response = await self._post(
+            self._payload("never-signed-in", "stranger@example.com"),
+        )
+        self.assertEqual(response.status_code, 204)
+
+        with self.assertRaises(Aborted):
+            await AutoConstructUser.ref("never-signed-in").get(self.context)
+
+    async def test_webhook_refreshes_existing_user(self):
+        await self._up(webhook_secret=_ORY_WEBHOOK_SECRET)
+        await self._sign_in("identity-1", "jane@example.com")
+
+        # The user changes their email in a settings flow; the webhook
+        # reaches `set_claims` and refreshes it immediately, without
+        # waiting for the next sign-in.
+        response = await self._post(
+            self._payload("identity-1", "jane@new.example"),
+        )
+        self.assertEqual(response.status_code, 204)
+
+        user = await AutoConstructUser.ref("identity-1").get(self.context)
+        self.assertEqual(user.email, "jane@new.example")
+        # The `User` still exists from the sign-in; the webhook
+        # updated it rather than constructing a new one.
+        self.assertEqual(user.profile_id, "profile-identity-1")
 
 
 class RequestedClaimsTest(unittest.TestCase):

--- a/tests/reboot/auto_construct_proto/BUILD.bazel
+++ b/tests/reboot/auto_construct_proto/BUILD.bazel
@@ -1,0 +1,42 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("//reboot:rules.bzl", "py_reboot_library")
+
+proto_library(
+    name = "test_proto",
+    srcs = ["test.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rbt/v1alpha1:options_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+py_reboot_library(
+    name = "test_py_reboot",
+    proto = "test.proto",
+    proto_library = ":test_proto",
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "test_servicer_py",
+    srcs = ["test_servicer.py"],
+    visibility = ["//tests/reboot:__subpackages__"],
+    deps = [
+        ":test_py_reboot",
+    ],
+)
+
+py_test(
+    name = "test_py",
+    srcs = ["test.py"],
+    main = "test.py",
+    deps = [
+        ":test_py_reboot",
+        ":test_servicer_py",
+        "//reboot/aio:applications_py",
+        "//reboot/aio:tests_py",
+    ],
+)

--- a/tests/reboot/auto_construct_proto/test.proto
+++ b/tests/reboot/auto_construct_proto/test.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package tests.reboot.auto_construct_proto;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+import "rbt/v1alpha1/options.proto";
+
+// A proto-defined (i.e. non-Pydantic) state that is auto-constructed
+// `PER_USER_ID`. The framework injects an overridable `Create`
+// factory and an overridable `SetClaims` claims-delivery method. This
+// exercises the proto codegen path for claims delivery, in which the
+// framework's native claim values must be converted into the
+// `google.protobuf.Value`s the `SetClaims` request carries — a path a
+// Pydantic state, whose request accepts native values directly, never
+// takes.
+message User {
+  option (rbt.v1alpha1.state) = {
+    auto_construct: PER_USER_ID
+  };
+
+  string email = 1;
+  int32 update_count = 2;
+}
+
+message UserSetClaimsRequest {
+  map<string, google.protobuf.Value> claims = 1;
+}
+
+message GetResponse {
+  string email = 1;
+  int32 update_count = 2;
+}
+
+service UserMethods {
+  rpc Create(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (rbt.v1alpha1.method).transaction = {
+      constructor: {}
+    };
+  }
+
+  rpc SetClaims(UserSetClaimsRequest) returns (google.protobuf.Empty) {
+    option (rbt.v1alpha1.method).transaction = {
+    };
+  }
+
+  rpc Get(google.protobuf.Empty) returns (GetResponse) {
+    option (rbt.v1alpha1.method).reader = {
+    };
+  }
+}

--- a/tests/reboot/auto_construct_proto/test.py
+++ b/tests/reboot/auto_construct_proto/test.py
@@ -1,0 +1,59 @@
+import unittest
+from reboot.aio.applications import Application
+from reboot.aio.tests import Reboot
+from tests.reboot.auto_construct_proto.test_rbt import User
+from tests.reboot.auto_construct_proto.test_servicer import UserServicer
+
+_USER_ID = "test-user"
+
+
+class AutoConstructProtoClaimsTest(unittest.IsolatedAsyncioTestCase):
+    """Claims delivery to a *proto-defined* auto-construct state. Its
+    `SetClaims` request carries claims as
+    `map<string, google.protobuf.Value>`, but the framework delivers
+    them as native Python values, so it must convert them — a path a
+    Pydantic state (whose request accepts native values directly)
+    never takes, which is why it needs its own test."""
+
+    async def asyncSetUp(self) -> None:
+        self.rbt = Reboot()
+        await self.rbt.start()
+        await self.rbt.up(Application(servicers=[UserServicer]))
+        self.internal = self.rbt.create_external_context(
+            name=f"internal-{self.id()}",
+            app_internal=True,
+        )
+
+    async def asyncTearDown(self) -> None:
+        await self.rbt.stop()
+
+    async def test_authenticated_delivers_native_claims(self) -> None:
+        # `_authenticated` constructs the state (if needed) and
+        # delivers the claims through `set_claims`.
+        await UserServicer._authenticated(
+            self.internal,
+            state_id=_USER_ID,
+            claims={"email": "jane@example.com"},
+        )
+
+        response = await User.ref(_USER_ID).get(self.internal)
+        self.assertEqual(response.email, "jane@example.com")
+        self.assertEqual(response.update_count, 1)
+
+    async def test_set_claims_if_exists_delivers_native_claims(self) -> None:
+        # The webhook path also delivers native claims, to a state that
+        # already exists.
+        await UserServicer._authenticated(self.internal, state_id=_USER_ID)
+        await UserServicer._set_claims_if_exists(
+            self.internal,
+            state_id=_USER_ID,
+            claims={"email": "jane@example.com"},
+        )
+
+        response = await User.ref(_USER_ID).get(self.internal)
+        self.assertEqual(response.email, "jane@example.com")
+        self.assertEqual(response.update_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/reboot/auto_construct_proto/test_servicer.py
+++ b/tests/reboot/auto_construct_proto/test_servicer.py
@@ -1,0 +1,48 @@
+from reboot.aio.auth.authorizers import allow
+from reboot.aio.contexts import ReaderContext, TransactionContext
+from tests.reboot.auto_construct_proto.test_rbt import User
+
+
+class UserServicer(User.Servicer):
+
+    def authorizer(self):
+        # A deliberately permissive authorizer: the framework still
+        # restricts `set_claims` to app-internal callers before
+        # consulting this.
+        return allow()
+
+    async def create(
+        self,
+        context: TransactionContext,
+        request: User.CreateRequest,
+    ) -> User.CreateResponse:
+        # Identity-independent setup would go here; this state has
+        # none, so the constructor just materializes an empty `User`.
+        return User.CreateResponse()
+
+    async def set_claims(
+        self,
+        context: TransactionContext,
+        request: User.SetClaimsRequest,
+    ) -> User.SetClaimsResponse:
+        # `request.claims` is a `map<string, google.protobuf.Value>`;
+        # a verified `email` claim arrives as a string-valued `Value`.
+        # That the framework delivered a usable `Value` here (rather
+        # than the native `str` it starts with) is exactly what this
+        # test exercises.
+        email_value = request.claims.get("email")
+        self.state.email = (
+            email_value.string_value if email_value is not None else ""
+        )
+        self.state.update_count += 1
+        return User.SetClaimsResponse()
+
+    async def get(
+        self,
+        context: ReaderContext,
+        request: User.GetRequest,
+    ) -> User.GetResponse:
+        return User.GetResponse(
+            email=self.state.email,
+            update_count=self.state.update_count,
+        )

--- a/tests/reboot/ping_api_rbt.golden.py
+++ b/tests/reboot/ping_api_rbt.golden.py
@@ -17353,16 +17353,29 @@ class UserBaseServicer(IMPORT_reboot_aio_servicers.Servicer):
         # e.g. a per-user state on every sign-in. We derive a
         # deterministic idempotency key from the state ID so that the
         # construct is a NOOP once the state exists (even across
-        # different contexts). We prefer this over catching the
-        # `StateAlreadyConstructed` error that would otherwise result,
-        # since that logs an `ERROR` to user-visible logs.
+        # different contexts), without the `ERROR` that catching
+        # `StateAlreadyConstructed` alone would log on every sign-in.
         idempotency_key = IMPORT_uuid.uuid5(
             IMPORT_uuid.NAMESPACE_URL,
             f"urn:dev.reboot:auto-construct:User:{state_id}",
         )
-        await User.idempotently(
-            key=idempotency_key,
-        ).create(context, state_id)
+        try:
+            await User.idempotently(
+                key=idempotency_key,
+            ).create(context, state_id)
+        except User.CreateAborted as aborted:
+            # The state may predate auto-construction: one constructed
+            # through some explicit flow before the application adopted
+            # `auto_construct` (or before this user first signed in
+            # through OAuth) aborts with `StateAlreadyConstructed`,
+            # since the idempotency key only dedupes *this* call site.
+            # The state exists, which is all this call is for, so
+            # swallow it; anything else is a real error and propagates.
+            if not isinstance(
+                aborted.error,
+                IMPORT_rbt_v1alpha1.errors_pb2.StateAlreadyConstructed,
+            ):
+                raise
         # The two calls are deliberately sequential rather than wrapped
         # in one transaction: an idempotent construct followed by a
         # full-replace `set_claims` compose convergently.

--- a/tests/reboot/ping_api_rbt.golden.py
+++ b/tests/reboot/ping_api_rbt.golden.py
@@ -17376,6 +17376,43 @@ class UserBaseServicer(IMPORT_reboot_aio_servicers.Servicer):
                 context, claims=claims
             )
 
+    @staticmethod
+    async def _set_claims_if_exists(
+        context: IMPORT_reboot_aio_external.ExternalContext,
+        state_id: str,
+        claims: IMPORT_typing.Mapping[str, IMPORT_typing.Any],
+    ) -> None:
+        """Deliver a user's verified identity claims to their
+        `User` — but ONLY if it already exists;
+        never construct it. This is for identity changes that arrive
+        outside a sign-in (e.g. an identity provider webhook, which
+        fires for every identity in the provider, most of which may
+        never have signed into this application): materializing a
+        `User` for an identity that never signed in
+        would be wrong.
+
+        Racing a user's very first sign-in is safe: if the sign-in
+        constructs the state first, this delivery lands; if it has
+        not yet, this skips and the sign-in's own claims delivery
+        carries the current claims.
+        """
+        try:
+            await User.ref(state_id).always().set_claims(
+                context, claims=claims
+            )
+        except User.SetClaimsAborted as aborted:
+            # A `set_claims` on a state that was never
+            # constructed aborts with `StateNotConstructed` (and logs
+            # one `WARNING`); that is exactly the "identity never
+            # signed in here" case, so swallow it. Any other abort is
+            # a real error and propagates.
+            if isinstance(
+                aborted.error,
+                IMPORT_rbt_v1alpha1.errors_pb2.StateNotConstructed,
+            ):
+                return
+            raise
+
     def ref(
         self,
         *,

--- a/tests/reboot/pydantic/auto_construct_user/test.py
+++ b/tests/reboot/pydantic/auto_construct_user/test.py
@@ -158,6 +158,27 @@ class AutoConstructUserTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(user_response.email, "a@example.com")
         self.assertEqual(user_response.update_count, 3)
 
+    async def test_authenticated_tolerates_preexisting_state(self) -> None:
+        # A `User` may predate auto-construction: one constructed
+        # through some explicit flow (here: a direct `create` under a
+        # different idempotency key, standing in for however the
+        # application materialized users before it adopted
+        # auto-construction). `_authenticated` must treat it as
+        # already-constructed — and still deliver claims — rather
+        # than aborting with `StateAlreadyConstructed`.
+        user_id = "preexisting-user"
+        await User.idempotently("explicit-construction"
+                               ).create(self.internal, user_id)
+
+        await UserServicer._authenticated(
+            self.internal,
+            state_id=user_id,
+            claims={"email": "jane@example.com"},
+        )
+
+        user_response = await User.ref(user_id).get(self.internal)
+        self.assertEqual(user_response.email, "jane@example.com")
+
     async def test_mint_with_claims_delivers(self) -> None:
         # The test harness mirrors production: minting a token with
         # claims delivers them through the same chokepoint, so a


### PR DESCRIPTION
This PR adds an `Ory` OAuth provider (what Reboot Cloud will use).

This PR also adds the mechanics needed to support "reactive" claims: Ory can send a webhook when claims change (e.g. a user changes their email address), and we now support receiving that webhook and immediately updating claims.

Finally, because Reboot Cloud is migrating from a hand-rolled `User`-construction story to "proper" `User`-auto-construction, we must support cases where the `User` being auto-constructed was actually already constructed by a different mechanism earlier. This PR adds a commit for that edge case.

Please see individual commits!