### PR TITLE
Cancel superseded Development Containers CI runs per PR

### DIFF
--- a/.github/workflows/development_containers_build_test.yml
+++ b/.github/workflows/development_containers_build_test.yml
@@ -23,6 +23,32 @@ on:
   # selected branch's version (with secrets) to validate them.
   workflow_dispatch:
 
+concurrency:
+  # Have at most one of these workflows running per branch, cancelling older
+  # runs that haven't completed yet when they become obsolete.
+  #
+  # When pushing new commits to a PR, each one of those commits triggers a new
+  # workflow run that would normally run to completion, even when subsequent
+  # pushes to the PR make their result obsolete. This consumes resources for no
+  # benefit. We override that default behavior to save resources, cancelling any
+  # older still-running workflows when a new workflow starts.
+  #
+  # See documentation about the `github` context variables here:
+  #   https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+  #
+  # We key the group on the PR number, not `github.ref`: under
+  # `pull_request_target` `github.ref` is the base branch (e.g.
+  # `refs/heads/main`) and so is identical for every PR, which would
+  # collapse all PRs into one group. `merge_group` runs have no PR
+  # number, so they fall back to `github.ref` (the unique merge-queue
+  # ref).
+  group: >-
+    ${{ github.workflow }}-${{
+    github.event.pull_request.number || github.ref }}
+  # Cancel superseded runs for a PR when it gets new commits, but let
+  # every `merge_group` run finish so each queued commit is tested.
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 jobs:
   # External fork pull requests run with `pull_request_target`, which
   # grants our secrets and a read/write token even though the PR's own

--- a/.github/workflows/development_containers_build_test.yml
+++ b/.github/workflows/development_containers_build_test.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Have at most one of these workflows running per branch, cancelling older
+  # Have at most one of these workflows running per PR, cancelling older
   # runs that haven't completed yet when they become obsolete.
   #
   # When pushing new commits to a PR, each one of those commits triggers a new


### PR DESCRIPTION
## Problem

`Development Containers - Build and Test` had no `concurrency` block,
so pushing a new commit to a PR left the previous commit's run going
and started another alongside it. Superseded runs piled up and
consumed CI resources for results that were already obsolete (two of
these workflows could be in progress for the same PR at once).

The sibling `build_and_test.yml` already cancels its own superseded
runs per PR; this workflow was simply missing the same guard.

## Change

Added the same per-PR `concurrency` group `build_and_test.yml` uses:

- `group` keyed on `github.event.pull_request.number`, so each PR gets
  its own group and different PRs still run their CI in parallel;
  `merge_group` runs (no PR number) fall back to `github.ref`, which is
  the unique merge-queue ref.
- `cancel-in-progress` only for `pull_request_target`, so every
  `merge_group` run finishes and each queued commit is still tested.

A new push now cancels the PR's obsolete Development Containers run
instead of running both to completion. Those jobs run on Linux runners
only, so the superseded run tears down quickly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
