### PR TITLE
Bazel: harden third-party archive fetches against transient download failures

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -184,6 +184,15 @@ build:macos --copt=-Werror=unguarded-availability
 # credentials isn't a problem.
 common --repo_env=OCI_GET_TOKEN_ALLOW_FAIL=1
 
+# Retry the downloads that repository rules like `http_archive` make.
+# This flag defaults to `0`, meaning Bazel makes exactly one attempt
+# per URL and then fails the whole invocation, so a single slow
+# response from a third-party host is enough to break a build. Five
+# attempts, with the exponential backoff Bazel applies between them,
+# is the same budget our `Dockerfile`s give their `curl`/`wget`
+# fetches.
+common --experimental_repository_downloader_retries=5
+
 # Normally, on restart, Bazel will check that its `bazel-bin` and
 # `bazel-out` directories are untouched. As part of this for every file
 # in those directories it will check the modification time, possibly

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -119,7 +119,7 @@ def repos():
         sha256 = "8ada9d88e51ebf5a1fdff37d75ed41d51f5e677cdbeafb0a22dda54747d6e07e",
         strip_prefix = "buildifier-prebuilt-6.4.0",
         urls = [
-            "http://github.com/keith/buildifier-prebuilt/archive/6.4.0.tar.gz",
+            "https://github.com/keith/buildifier-prebuilt/archive/6.4.0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Three CI runs failed today, all in the same way: a Bazel repository rule tried to download a third-party archive, the download timed out, and the whole invocation died.

Nothing about these is a real failure — the archives exist and their contents never changed. While CI has `--remote_cache` (Bazel's **action** cache), that does not cover `http_archive` downloads at all, so every CI run re-downloads these straight from `github.com`.

This PR adds two robustness fixes:

* **`buildifier_prebuilt` is fetched over `https://`.** It was the only archive in the repository declared with a plain `http://` URL; that bought an extra redirect hop and a little bit of insecurity.

* **Repository downloads are retried.** See the caveat below — that'll address the failures I experienced today no matter what package causes them.