### PR TITLE
Rework the app-building skills from measured agent behaviour

### DIFF
--- a/documentation/docs/overview.mdx
+++ b/documentation/docs/overview.mdx
@@ -3,10 +3,10 @@ id: overview
 slug: /
 ---
 
-import { CardSection, Card } from "../src/components/Cards";
 import Link from "@docusaurus/Link";
-import TSLogo from "../static/img/ts-logo.svg";
+import { Card, CardSection } from "../src/components/Cards";
 import PythonLogo from "../static/img/python-logo.svg";
+import TSLogo from "../static/img/ts-logo.svg";
 
 # Build Apps with Reboot
 

--- a/reboot/plugin/README.md
+++ b/reboot/plugin/README.md
@@ -150,9 +150,10 @@ Build a todo list chat app with drag-to-reorder
 ```
 
 In Claude Code you can also invoke a skill directly, e.g.
-`/chat-app Build a todo list app`. Either way the builder skills plan
-first — they analyze your description, propose a state model and method
-map, and wait for your approval before writing any code.
+`/chat-app Build a todo list app`. Either way the builder skills
+settle the design first — they analyze your description and state the
+state model and method map they are about to build, so you can redirect
+before the code exists.
 
 ## Skill reminders
 

--- a/reboot/plugin/skills/chat-app/SKILL.md
+++ b/reboot/plugin/skills/chat-app/SKILL.md
@@ -59,35 +59,60 @@ README for the manual install, team auto-enable, and the Codex
   starts the backend and frontend, and opens the setup wizard (from
   which the user can launch MCPJam on demand).
 
-## Read These From `python` First
+## Which References to Read, and When
 
-Before scaffolding, load the references that cover the backend
-mechanics. The patterns in this skill assume you've read them and just
-show the chat-app-specific shape on top.
+The backend mechanics live in the `python` skill's references; the
+chat-app-specific shape on top of them lives in this skill's own
+`references/`. Neither set is restated inline below.
 
-**Always relevant:**
+Everything you read stays in the conversation and is re-sent on
+every later turn, so **read each reference at the step that needs
+it** — not all of them up front — and read each one **once**. The
+groups below are in build order, and each reference appears in
+exactly one of them — the step that needs it.
+
+> **Never read `web-app/references/*` for a chat app.** They cover
+> the standalone browser SPA — a top-level `web/` Vite shell, the
+> `VITE_REBOOT_URL` backend URL, `<RebootClientProvider>`,
+> browser sign-in buttons — none of which apply to the nested
+> `frontend/mcp/<name>/` bundles an MCP host loads. The chat-app
+> equivalents are
+> [`references/react-scaffolding.md`](references/react-scaffolding.md)
+> and [`references/react-app-tsx.md`](references/react-app-tsx.md).
+
+**Before the project shell** (`.python-version`, `pyproject.toml`,
+`.rbtrc`, `.mypy.ini`, `main.py`):
+
+- [`references/project-shell.md`](references/project-shell.md) —
+  `.python-version`, `.rbtrc` deltas (HMR + dist configs),
+  `pyproject.toml` extras, `main.py` shape, the `example_prompts.py`
+  module wired into `Application(example_prompts=...)`,
+  durable-state setup.
+- `python/references/lifecycle-{project-setup,rbtrc,application-entry,initialize-hook}.md` — the canonical layout, the CLI flags, the
+  `Application(...)` constructor, the `initialize` hook.
+
+**Before the API definition:**
 
 - `python/references/patterns-common-gotchas.md` — recurring trips
-  (`self.ref().state_id`, kwargs convention, `--name` vs.
-  `--application-name`, etc.).
+  (`self.ref().state_id`, kwargs convention, a `ref()` belongs to
+  one context, the auto-constructed `User` type, `--name` vs.
+  `--application-name`).
 - `python/references/api-pydantic.md` — pydantic API rules (every
   Field needs a zero-value default; non-Optional `Model`-typed
   fields can't take defaults).
-
-**Defining the API:**
-
 - `python/references/api-methods.md` — factory → context type
   mapping (Reader/Writer/Transaction/Workflow).
-- `python/references/api-errors.md` — typed errors.
-- `python/references/state-collections.md` — **always read when
-  the app has any "list of X" concept.** Decides whether each X
-  should be its own state `Type` (most of the time, yes) and picks
-  between in-state `list[Sub]`, in-state `list[str]` of foreign
-  IDs, or an `OrderedMap` of foreign IDs. The trap is
-  defaulting to `list[Person]`/`list[Post]`/`list[Task]` on `User`
-  for entity collections — see Step 1 of that reference. A second
-  trap: a collection **synced or scraped from an external system**
-  (a repo's issues, a mailbox, an RSS feed) is unbounded by
+- `python/references/api-errors.md` — typed errors, when the API
+  declares any.
+- `python/references/state-collections.md` — **always read when the
+  app has any "list of X" concept.** Decides whether each X should
+  be its own state `Type` (most of the time, yes) and picks between
+  in-state `list[Sub]`, in-state `list[str]` of foreign IDs, or an
+  `OrderedMap` of foreign IDs. The trap is defaulting to
+  `list[Person]`/`list[Post]`/`list[Task]` on `User` for entity
+  collections — see Step 1 of that reference. A second trap: a
+  collection **synced or scraped from an external system** (a
+  repo's issues, a mailbox, an RSS feed) is unbounded by
   definition — model it as an `OrderedMap`; a size cap never makes
   it bounded.
 - `python/references/state-nested-models.md` — the same rule from
@@ -98,19 +123,52 @@ show the chat-app-specific shape on top.
   transient cache), split each into its own `Type`. Critical for the
   `User` front door, which otherwise turns into a God actor and
   serializes unrelated writers.
+- [`references/api-method-types.md`](references/api-method-types.md)
+  — the pydantic API file for a chat app: `User`-type front door,
+  `mcp=Tool()` / `mcp=None`, `UI()` (including parameterized UI
+  props), `factory=True` on `create`, the `Workflow(...)`
+  declaration shape. Full Counter API example.
+- [`references/api-state-shapes.md`](references/api-state-shapes.md)
+  — two recurring state shapes: `list[Item]` with
+  `default_factory=list`; single nested `Model` sub-objects as
+  `Optional[X] = Field(tag=N, default=None)` hydrated in factory
+  `create` (Gotcha #13). The state-inside-state regression and how
+  to compose state actors via string ID + `ref(id)`.
+- [`references/gotchas.md`](references/gotchas.md) — the numbered
+  MCP-chat-app trip list (1–19): `mcp=Tool()`/`mcp=None` required,
+  `factory=True` on app-type `create`, `MyType.ref()` not
+  `cls.ref()`/`self.ref()` in workflows, `.schedule()` from a
+  Transaction, Optional+`default=None` for nested Models, `.read()`
+  only on a no-arg ref inside a workflow, method-name PascalCase →
+  generated `<Type>.<Method>Request`.
 
-**Implementing Servicers:**
+**Before the servicer:**
 
-- `python/references/servicer-{reader,writer,transaction,constructor,authorizer}.md` — one per context type.
+- `python/references/servicer-{reader,writer,transaction,constructor}.md` — one per context type you actually declared.
 - `python/references/rpc-refs.md` — `self.ref().state_id` (never
   `self.state_id`); `self.ref().schedule(...)`.
-- `python/references/rpc-calls.md` — kwargs not Request wrappers.
+- `python/references/rpc-calls.md` — kwargs, not Request wrappers.
 - `python/references/rpc-constructor-calls.md` —
   `Service.create(context, id)` semantics.
+- `python/references/servicer-workflow.md` — only when you declared
+  a `Workflow`, and then top to bottom: the `@classmethod` /
+  `WorkflowContext` declaration shape, the call-classification
+  decision tree (Reboot scopes vs. `at_least_once` vs.
+  `at_most_once`), `context.loop`, inline state writes,
+  `until` / `until_changes`, and workflow exit semantics.
+- [`references/servicer-patterns.md`](references/servicer-patterns.md)
+  — the chat-app servicer shapes: `UserServicer` calling
+  `<X>.create(context)`, a Workflow Servicer with `MyType.ref()`
+  (no-arg) magic, inline writers via
+  `.per_workflow("alias").write(context, fn)` /
+  `.per_iteration("alias").write(...)` / `.always().write(...)`,
+  scheduling a workflow from a Transaction with `.schedule()`.
 
-**Auth (write rules from day one — see "Auth" under Key Framework Concepts):**
+**Before the authorizers** (write rules from day one — see "Auth"
+under Key Framework Concepts):
 
-- `python/references/auth-allow-if.md`,
+- `python/references/servicer-authorizer.md`,
+  `python/references/auth-allow-if.md`,
   `python/references/auth-built-in-predicates.md`,
   `python/references/auth-custom-predicates.md` — the predicate
   machinery. Chat apps use `oauth=` for identity, so real rules are
@@ -118,42 +176,89 @@ show the chat-app-specific shape on top.
 - `python/references/auth-allow-deny.md` — narrow uses of
   unconditional rules; specifically, when **not** to reach for
   `allow()`.
+- [`references/auth-oauth-providers.md`](references/auth-oauth-providers.md)
+  — choosing your `Application(oauth=...)` provider via
+  `OAuthProviderByEnvironment(dev=..., prod=...)` (the recommended
+  `dev=Development(), prod=Google(...)` shape; a selected `None` arm
+  fails startup), the `Google` / `GitHub` / `Auth0` / `Development` /
+  `Anonymous` providers and where credentials come from (incl. the
+  `/__/oauth/callback` URL), and the user-ID-namespace gotcha that
+  makes switching providers after launch infeasible — choose
+  deliberately **before** real users have state.
+- [`references/auth-custom-oauth-provider.md`](references/auth-custom-oauth-provider.md)
+  — **writing your own OAuth provider** when none of the shipped
+  ones fits (self-hosted Keycloak, internal SSO, an IdP Auth0 can't
+  broker): subclass `RegisteredOAuthProvider`, implement
+  `authorization_url` + `exchange_code` → `ExchangeResult` (the user
+  id must be **stable** — it becomes `context.auth.user_id`), the
+  `validate()` / `mount_routes()` hooks, and `token_service_id` +
+  `OAuthTokens` for `store_tokens=True` support.
+- [`references/auth-store-tokens.md`](references/auth-store-tokens.md)
+  — **acting on the user's behalf** at an external service: when the
+  API belongs to your `Application(oauth=...)` identity provider,
+  add extra OAuth `scopes=[...]` + `store_tokens=True` (needs
+  `oauth_library()` + `ciphertext_library()` +
+  `ordered_map_library()`) and the server captures its tokens.
+  Reboot stores **the provider's own tokens only** (an `Auth0`
+  sign-in stores an Auth0 token, not the upstream Google token). The
+  full host-agnostic recipe — custom OAuth endpoints for any _other_
+  service, reading tokens back, calling the API **inside a
+  `Workflow`**, refresh tokens, erasure — is
+  [`python/references/auth-external-api-calls.md`](../python/references/auth-external-api-calls.md).
 
-**Workflows:**
+**Before the frontend:**
 
-- `python/references/servicer-workflow.md` — the single,
-  comprehensive workflow reference. Read it top to bottom: the
-  `@classmethod` / `WorkflowContext` declaration shape, the
-  call-classification decision tree (Reboot scopes vs.
-  `at_least_once` vs. `at_most_once`), `context.loop`, inline state
-  writes,
-  `until` / `until_changes`, and workflow exit semantics.
+- [`references/react-scaffolding.md`](references/react-scaffolding.md)
+  — the `frontend/` shell: `package.json` (`npm run build` runs
+  `build.mjs`, which auto-discovers and builds every UI),
+  `vite.config.ts` (load-bearing — copy exactly), `build.mjs`,
+  `tsconfig.json` / `tsconfig.app.json` / `tsconfig.node.json`,
+  `index.css` theme variables, `mcp/<name>/index.html`,
+  `mcp/<name>/main.tsx`.
+- [`references/react-app-tsx.md`](references/react-app-tsx.md) —
+  `App.tsx` itself: what an MCP UI component renders, and the full
+  Counter `App.tsx` + `App.module.css` example.
+- `python/references/react-generated-client.md` — what
+  `rbt generate --react=` emits, identically for every surface: the
+  `use<Type>()` overloads, the three-field reader return, why
+  mutations resolve to `{ response, aborted }` instead of throwing,
+  the typed error classes, and the snake→camel naming rules.
+- [`references/pop-out-to-web-app.md`](references/pop-out-to-web-app.md)
+  — only when a widget needs a "pop out into the web app" button:
+  recover the bound entity ID with the generated hook's `state_id`,
+  build a deep-link URL, and open it via the host's
+  `useMcpApp().openLink({ url })` (the sandboxed iframe blocks
+  `window.open`) with a `window.open` fallback. The web-app side
+  reads the ID from the URL; a shared `rbt_session` keeps the user
+  signed in across surfaces.
 
-**Project shell:**
+**Before the tests:** the three `python/references/testing-*.md`
+files, plus `python/references/patterns-idempotency.md` — it
+explains `IdempotencyUncertainError`, which is otherwise the one
+runtime error whose cause is not in any reference you have read.
 
-- `python/references/lifecycle-{project-setup,rbtrc,application-entry,initialize-hook}.md` — the canonical layout,
-  the CLI flags, the `Application(...)` constructor, the
-  `initialize` hook.
+**Before running the app:** the [`run` skill](../run/SKILL.md).
 
-## This Skill's References
+If you find yourself grepping the framework's installed source or a
+generated file to answer a question, the next section is for you —
+do not explore it in the main conversation.
 
-Chat-app–specific topics, organized by layer. Read them on demand
-the same way you would any other skill reference — the patterns
-they cover aren't restated inline below.
+## Never Read Generated or Installed Source in the Main Thread
 
-| Reference                                                                              | What's in it                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`references/project-shell.md`](references/project-shell.md)                           | `.python-version`, `.rbtrc` deltas (HMR + dist configs), `pyproject.toml` extras, `main.py` shape, the `example_prompts.py` module wired into `Application(example_prompts=...)`, durable-state setup.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| [`references/api-method-types.md`](references/api-method-types.md)                     | The pydantic API file. `User`-type front door, `mcp=Tool()` / `mcp=None`, `UI()` (including parameterized UI props), `factory=True` on `create`, `Workflow(...)` declaration shape. Full Counter API example.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| [`references/api-state-shapes.md`](references/api-state-shapes.md)                     | Two recurring state shapes: `list[Item]` with `default_factory=list`; single nested `Model` sub-objects as `Optional[X] = Field(tag=N, default=None)` hydrated in factory `create` (Gotcha #13). The state-inside-state regression and how to compose state actors via string ID + `ref(id)`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| [`references/servicer-patterns.md`](references/servicer-patterns.md)                   | Servicer-side patterns: `UserServicer` calling `<X>.create(context)`, Workflow Servicer with `MyType.ref()` (no-arg) magic, inline writers via `.per_workflow("alias").write(context, fn)` / `.per_iteration("alias").write(...)` / `.always().write(...)`, scheduling a workflow from a Transaction with `.schedule()`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| [`references/react-scaffolding.md`](references/react-scaffolding.md)                   | The `frontend/` shell: `package.json` (`npm run build` runs `build.mjs`, which auto-discovers and builds every UI), `vite.config.ts` (load-bearing — copy exactly), `build.mjs`, `tsconfig.json` / `tsconfig.app.json` / `tsconfig.node.json`, `index.css` theme variables, `mcp/<name>/index.html`, `mcp/<name>/main.tsx`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| [`references/react-app-tsx.md`](references/react-app-tsx.md)                           | `App.tsx` — generated `use<Type>()` hook usage (reader subscriptions + mutation calls), Python-snake → TypeScript-camel field naming, Zod-validated request/response types. Full Counter `App.tsx` + `App.module.css` example.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| [`references/pop-out-to-web-app.md`](references/pop-out-to-web-app.md)                 | Adding a "pop out into the web app" button to a UI widget: recover the bound entity ID with the generated hook's `state_id`, build a deep-link URL, and open it via the host's `useMcpApp().openLink({ url })` (the sandboxed iframe blocks `window.open`) with a `window.open` fallback. The web-app side reads the ID from the URL; shared `rbt_session` keeps the user signed in across surfaces.                                                                                                                                                                                                                                                                                                                                                                                                            |
-| [`references/gotchas.md`](references/gotchas.md)                                       | The numbered MCP-Chat-App–specific trip list (1–19): `mcp=Tool()`/`mcp=None` required, `factory=True` on app-type `create`, `MyType.ref()` not `cls.ref()`/`self.ref()` in workflows, `.schedule()` from a Transaction, Optional+`default=None` for nested Models, `.read()` only on no-arg ref inside a workflow, method-name PascalCase → generated `<Type>.<Method>Request`, etc.                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| [`references/auth-oauth-providers.md`](references/auth-oauth-providers.md)             | Choosing your `Application(oauth=...)` provider via `OAuthProviderByEnvironment(dev=..., prod=...)` (the recommended `dev=Development(), prod=Google(...)` shape; a selected `None` arm fails startup), the `Google` / `GitHub` / `Auth0` / `Development` / `Anonymous` providers and where credentials come from (incl. the `/__/oauth/callback` URL), and the user-ID-namespace gotcha that makes switching providers after launch infeasible — choose deliberately **before** real users have state.                                                                                                                                                                                                                                                                                                         |
-| [`references/auth-custom-oauth-provider.md`](references/auth-custom-oauth-provider.md) | **Writing your own OAuth provider** when none of the shipped ones fits (self-hosted Keycloak, internal SSO, an IdP Auth0 can't broker): subclass `RegisteredOAuthProvider`, implement `authorization_url` + `exchange_code` → `ExchangeResult` (the user id must be **stable** — it becomes `context.auth.user_id`), the `validate()` / `mount_routes()` hooks, and `token_service_id` + `OAuthTokens` for `store_tokens=True` support.                                                                                                                                                                                                                                                                                                                                                                         |
-| [`references/auth-store-tokens.md`](references/auth-store-tokens.md)                   | **Acting on the user's behalf** at an external service — the built-in `store_tokens=True` shortcut (works on any `oauth=` surface, web apps included): when the API belongs to your `Application(oauth=...)` identity provider, add extra OAuth `scopes=[...]` + `store_tokens=True` (needs `oauth_library()` + `ciphertext_library()` + `ordered_map_library()`) and the server captures its tokens. Reboot stores **the provider's own tokens only** (an `Auth0` sign-in stores an Auth0 token, not the upstream Google token). The full host-agnostic recipe — custom OAuth endpoints for any _other_ service, reading tokens back, calling the API **inside a `Workflow`**, refresh tokens, erasure — is [`python/references/auth-external-api-calls.md`](../python/references/auth-external-api-calls.md). |
+`*_rbt.py`, `*_rbt_react.ts`, `site-packages/`, `node_modules/`,
+and codegen templates run to tens of thousands of lines. Every one
+you open is re-sent on every remaining turn, which makes reading
+them the most expensive way in the system to learn a fact.
+
+The generated surfaces you actually need are written out in these
+references — the React client in
+`python/references/react-generated-client.md`, the backend shapes in
+the rest of `python/references/`. Use them.
+
+If something genuinely isn't covered, bound the output hard: a
+targeted `grep -n … | head -40`, or `sed -n '<start>,<end>p'` over
+a known range. Never a whole generated file, never an unbounded
+recursive grep.
 
 ## Workflow: Settle the Design, Then Build
 
@@ -605,7 +710,9 @@ a worked set are in
    and [`references/api-state-shapes.md`](references/api-state-shapes.md);
    field-level pydantic rules in
    `python/references/api-pydantic.md`.
-4. `uv run rbt generate`.
+4. `uv run rbt generate`. Don't read what it wrote: the signature
+   your servicer must match is in `python/references/api-methods.md`
+   ("The Servicer Signature Each Declaration Obliges").
 5. Write servicer (`backend/src/servicers/<name>.py`) — see
    [`references/servicer-patterns.md`](references/servicer-patterns.md);
    context-type rules in `python/references/servicer-*.md`.

--- a/reboot/plugin/skills/chat-app/SKILL.md
+++ b/reboot/plugin/skills/chat-app/SKILL.md
@@ -54,7 +54,7 @@ README for the manual install, team auto-enable, and the Codex
 - Adding features, state, or UI to an existing Reboot AI Chat App
 - Modifying state model, methods, or React UI in a Reboot AI Chat App
 - Running an existing Reboot AI Chat App — e.g. at the start of a
-  new session. This needs no Plan or Build phase: load the
+  new session. This needs no design or build phase: load the
   [`run` skill](../run/SKILL.md), which detects the app type,
   starts the backend and frontend, and opens the setup wizard (from
   which the user can launch MCPJam on demand).
@@ -155,19 +155,17 @@ they cover aren't restated inline below.
 | [`references/auth-custom-oauth-provider.md`](references/auth-custom-oauth-provider.md) | **Writing your own OAuth provider** when none of the shipped ones fits (self-hosted Keycloak, internal SSO, an IdP Auth0 can't broker): subclass `RegisteredOAuthProvider`, implement `authorization_url` + `exchange_code` → `ExchangeResult` (the user id must be **stable** — it becomes `context.auth.user_id`), the `validate()` / `mount_routes()` hooks, and `token_service_id` + `OAuthTokens` for `store_tokens=True` support.                                                                                                                                                                                                                                                                                                                                                                         |
 | [`references/auth-store-tokens.md`](references/auth-store-tokens.md)                   | **Acting on the user's behalf** at an external service — the built-in `store_tokens=True` shortcut (works on any `oauth=` surface, web apps included): when the API belongs to your `Application(oauth=...)` identity provider, add extra OAuth `scopes=[...]` + `store_tokens=True` (needs `oauth_library()` + `ciphertext_library()` + `ordered_map_library()`) and the server captures its tokens. Reboot stores **the provider's own tokens only** (an `Auth0` sign-in stores an Auth0 token, not the upstream Google token). The full host-agnostic recipe — custom OAuth endpoints for any _other_ service, reading tokens back, calling the API **inside a `Workflow`**, refresh tokens, erasure — is [`python/references/auth-external-api-calls.md`](../python/references/auth-external-api-calls.md). |
 
-## Workflow: Plan First, Then Build
+## Workflow: Settle the Design, Then Build
 
-**Always plan the design and get approval before writing code.** The
-state model is the foundation — getting entities, field types, or
-method types wrong means regenerating everything across 12+ files.
+**Always settle the design before writing code.** The state model
+is the foundation — getting entities, field types, or method types
+wrong means regenerating everything across 12+ files.
 
-### Plan Phase
+### Design Phase
 
 1. Analyze the user's description using the State Model Assessment
    below.
-2. Begin a plan for the user to approve (in Claude Code, enter plan
-   mode; in Codex, present the plan and wait for the go-ahead).
-3. Present the proposed design:
+2. State the design you are about to build:
    - `User` type and its methods (the MCP front door for creating new
      application-type instances and locating existing ones).
    - Application types: state shape (fields, types, tags).
@@ -179,20 +177,19 @@ method types wrong means regenerating everything across 12+ files.
      main user story — and most of them ending on a turn that
      renders a `UI()` component, not just a tool call (see
      "Example Prompts" under Key Framework Concepts).
-4. Get user approval before writing any files.
-5. Then execute the Step-by-Step Build Flow.
+3. Then execute the Step-by-Step Build Flow.
 
-For updates to existing apps, still plan: read current state, propose
-changes, confirm, then modify.
+For updates to existing apps, still work the design first: read
+current state, state the changes, then modify.
 
-### Writing the Plan for Human Review
+### Writing the Design for a Human Reader
 
-The plan is read by a **human who has not read the skill files**.
-They are evaluating the design — entities, collections, methods,
-auth — not verifying that you followed the skill. Write so the
-plan stands on its own.
+The design is read by a **human who has not read the skill files**.
+They are judging the design — entities, collections, methods,
+auth — not verifying that you followed the skill. Write so it
+stands on its own.
 
-**Don't quote skill-internal terms** when presenting the plan.
+**Don't quote skill-internal terms** when presenting the design.
 They mean nothing outside this skill:
 
 - `Shape A` / `Shape B` / `Shape C` — name the actual data
@@ -240,7 +237,7 @@ Nested model reasoning — GOOD:
 > own state actors because they have no lifecycle, methods, or
 > auth independent of the Person they belong to.
 
-**Escape hatch.** When the precise type name _is_ what the user
+**Escape hatch.** When the precise type name _is_ what the reader
 needs to see ("I'm proposing `OrderedMap` here, not `list[str]`"),
 name the type — but pair it with the plain-English reason in the
 same sentence. The rule is "no bare jargon", not "no technical
@@ -545,7 +542,7 @@ triggers a `UI()` method — phrase that turn as a natural "show me
 example, the "…and show me the counter" / "show me the wins counter"
 turns are exactly this: they resolve to the `Counter` UI and render the
 live component, not just a text reply. When you write the set, look at
-the method map from the plan: for each `UI()` method, make sure at
+the method map from the design: for each `UI()` method, make sure at
 least one example drives the user to it.
 
 They live in `backend/src/example_prompts.py` and are passed to
@@ -595,8 +592,7 @@ a worked set are in
 
 ## Step-by-Step Build Flow
 
-**Only execute after plan approval. All commands run from the
-application directory.**
+**All commands run from the application directory.**
 
 1. Create `.python-version`, `pyproject.toml`, `.rbtrc`, and
    `.mypy.ini` — see
@@ -629,7 +625,7 @@ application directory.**
 11. `cd frontend && npm run build`.
 12. **Write and run backend unit tests covering each user-facing
     user story before handing the app off.** Enumerate the user
-    stories from the plan — every action the user should be able
+    stories from the design — every action the user should be able
     to _do_ through the MCP tool surface (e.g. "create a new
     todo list", "add an item and see it listed", "rename a
     list"). Write one test method per user story in

--- a/reboot/plugin/skills/chat-app/references/react-app-tsx.md
+++ b/reboot/plugin/skills/chat-app/references/react-app-tsx.md
@@ -7,9 +7,16 @@ tags: react, app-tsx, hooks, useType, css-module, snake-camel, app-tsx-example, 
 
 ## React App.tsx — Generated Hooks and Component Patterns
 
-`frontend/mcp/<ui-name>/App.tsx` is the React component for one UI. The
-generated `use<Type>()` hook returns reader subscriptions and
-mutation functions:
+`frontend/mcp/<ui-name>/App.tsx` is the React component for one UI.
+
+> **The generated client contract is shared with web apps** — the
+> `use<Type>()` overloads, the `Use<Type>Api` surface, the three
+> fields a reader returns, why mutations resolve to
+> `{ response, aborted }` instead of throwing, and the typed error
+> classes are all in
+> [`python/references/react-generated-client.md`](../../python/references/react-generated-client.md).
+> Read that for the shapes; this file covers what is specific to a
+> UI rendered inside an MCP host.
 
 ```tsx
 import { useCounter } from "@api/<pkg>/v1/<name>_rbt_react";
@@ -17,12 +24,12 @@ import { useCounter } from "@api/<pkg>/v1/<name>_rbt_react";
 // useCounter() connects to the Counter state instance.
 const counter = useCounter();
 
-// Reader (WebSocket subscription, auto-updates):
-const { response, isLoading } = counter.useGet();
+// Reader (a live subscription — pushed on every change):
+const { response } = counter.useGet();
 const value = response?.value ?? 0;
 
-// Writer (direct call to Reboot backend):
-await counter.increment({ amount: 1 });
+// Mutation (resolves to `{ response, aborted }` — it never throws):
+const { aborted } = await counter.increment({ amount: 1 });
 ```
 
 For list state, the same pattern applies — use the generated hook for
@@ -70,13 +77,6 @@ follow-up read or to follow a navigation chain to another
 entity of the same Type), `useMcpToolData()` from
 `@reboot-dev/reboot-react` returns the raw `{ids, ...}` object
 the framework received.
-
-## Naming Convention: snake_case → camelCase
-
-The generated React bindings convert Python snake_case field names
-to TypeScript camelCase. Python `from_index` becomes TypeScript
-`fromIndex`. Same for every snake_case field name on every Request
-or Response Model.
 
 ## Generated React Imports
 

--- a/reboot/plugin/skills/python/SKILL.md
+++ b/reboot/plugin/skills/python/SKILL.md
@@ -224,6 +224,17 @@ docs would have prevented. Before writing code, load the references
 the task actually requires from the lists below. "Common gotchas"
 should be loaded for almost every task.
 
+Everything you read stays in the conversation and is re-sent on every
+later turn, so read a reference at the step that needs it rather than
+all of them up front, and read each one **once**. That cost is also
+why generated and installed source — `*_rbt.py`, `*_rbt_react.ts`,
+`site-packages/`, `node_modules/`, codegen templates — is the most
+expensive place in the system to learn a fact: the shapes worth
+knowing are written out in the references below. When something
+genuinely isn't covered, bound the output hard (a targeted
+`grep -n … | head -40`, or `sed -n '<start>,<end>p'` over a known
+range), never a whole generated file.
+
 ### Building a workflow
 
 - `references/servicer-workflow.md` — **the** single, comprehensive

--- a/reboot/plugin/skills/python/SKILL.md
+++ b/reboot/plugin/skills/python/SKILL.md
@@ -478,6 +478,12 @@ above lists the right ones grouped by task type. The full catalog:
 - `references/testing-harness.md`
 - `references/testing-external-context.md`
 
+**Frontend** (shared by `web-app` and `chat-app`):
+
+- `references/react-generated-client.md` — what
+  `rbt generate --react=` emits: hook overloads, `Use<Type>Api`,
+  reader/mutation return shapes, typed errors, naming rules.
+
 **Patterns** (`patterns-`):
 
 - `references/patterns-error-handling.md`

--- a/reboot/plugin/skills/python/references/api-methods.md
+++ b/reboot/plugin/skills/python/references/api-methods.md
@@ -64,6 +64,65 @@ BankMethods = Methods(
 )
 ```
 
+## The Servicer Signature Each Declaration Obliges
+
+`rbt generate` turns every `Methods(...)` entry into one method
+declaration on `<Type>.Servicer`, and the servicer you write must
+match it. The whole contract is these six lines — there is nothing
+further to learn by opening the generated `*_rbt.py`, which is tens
+of thousands of lines:
+
+```python
+class AnyNameServicer(<Type>.Servicer):    # subclass this alias
+
+    # `@classmethod`, for a `Workflow(...)` method only.
+    async def <entry_name>(                # snake_case, as declared
+        self,                              # `cls` for a `Workflow`
+        context: <Kind>Context,            # per the factory, above
+        request: <Type>.<Entry>Request,   # omitted if `request=None`
+    ) -> <Type>.<Entry>Response:          # `None` if `response=None`
+```
+
+`<Entry>` is the PascalCase form of the entry name: `add_task`
+declared on `Type("TaskList", ...)` gives `TaskList.AddTaskRequest` /
+`TaskList.AddTaskResponse`, while the method you write stays
+snake_case. So
+
+```python
+add_task=Transaction(
+    request=AddTaskRequest, response=AddTaskResponse, mcp=None,
+),
+lists=Reader(request=None, response=ListsResponse, mcp=None),
+ensure=Transaction(request=None, response=None, mcp=None),
+```
+
+obliges exactly:
+
+```python
+async def add_task(
+    self,
+    context: TransactionContext,
+    request: TaskList.AddTaskRequest,
+) -> TaskList.AddTaskResponse: ...
+
+async def lists(self, context: ReaderContext) -> User.ListsResponse: ...
+
+async def ensure(self, context: TransactionContext) -> None: ...
+```
+
+**Two shapes in the generated file look like contradictions of this.
+Both are real, and neither is what you write:**
+
+- A **PascalCase twin** of every method (`AddTask` next to
+  `add_task`) that delegates to the snake_case one. It keeps
+  servicers written before the snake_case rename working. Implement
+  the snake_case method.
+- A **`state:` parameter**, in signatures like
+  `(self, context, state, request)`. Those belong to
+  `<Type>.singleton.Servicer`, a variant the framework uses for its
+  own singletons. Applications subclass `<Type>.Servicer` and reach
+  state through `self.state`.
+
 ## `factory=True` Marks the Creation Method
 
 A `Writer` or `Transaction` with `factory=True` is the explicit

--- a/reboot/plugin/skills/python/references/auth-allow-deny.md
+++ b/reboot/plugin/skills/python/references/auth-allow-deny.md
@@ -126,7 +126,6 @@ A rule's `execute` returns one of three outcomes:
 
 ## One Authorizer per Servicer
 
-`def authorizer(self)` returns a single rule that applies to every
-method on the Servicer. Per-method differentiation (e.g. allow reads
-but gate writes) requires a custom authorizer subclass — see
-`auth-custom-predicates.md`.
+One rule covers every method on the Servicer; see
+`servicer-authorizer.md` for what to do when methods need
+different rules.

--- a/reboot/plugin/skills/python/references/auth-custom-predicates.md
+++ b/reboot/plugin/skills/python/references/auth-custom-predicates.md
@@ -62,13 +62,101 @@ def authorizer(self):
     return allow_if(all=[has_verified_token, is_team_member])
 ```
 
+## Annotate Predicates, or `mypy` Fails
+
+The examples above are unannotated for brevity, but a project that
+runs `mypy` needs the annotations — without them `allow_if` reports
+`Argument "any" ... has incompatible type "list[function]"; expected "Sequence[AuthorizerCallable[...]]"`, and a helper that returns a
+rule reports `Need type annotation`. The shapes that type-check:
+
+Annotate `state` with the **pydantic state model from your API
+definition** — the same `<X>State` class you declared in
+`api/<pkg>/v1/<name>.py`. That is what the runtime passes: in a
+pydantic app a predicate receives `<pkg>.v1.<name>.TaskListState`.
+
+> **Not** `<Type>Authorizer.StateType` / `.RequestTypes`. The
+> generated `<Type>Authorizer` class does expose those aliases, but
+> they name the **protobuf** types (`<name>_pb2.TaskList`), which is
+> not what a pydantic app's predicate is handed. They type-check —
+> protobuf and pydantic carry the same field names — while
+> describing the wrong class, which is worse than `Any`.
+
+```python
+from typing import Any
+
+import rbt.v1alpha1.errors_pb2 as errors
+from reboot.aio.auth.authorizers import (
+    Authorizer,
+    AuthorizerRule,
+    allow_if,
+    is_app_internal,
+)
+from reboot.aio.contexts import ReaderContext
+from <pkg>.v1.<name> import TaskListState
+
+
+def is_owner_or_member(
+    *,
+    context: ReaderContext,
+    state: TaskListState | None = None,
+    **kwargs: Any,
+) -> Authorizer.Decision:
+    if context.auth is None or context.auth.user_id is None:
+        return errors.Unauthenticated()
+    if state is not None and state.owner_id == context.auth.user_id:
+        return errors.Ok()
+    return errors.PermissionDenied()
+
+
+# A helper that returns a rule needs its return type spelled out.
+def owner_or_member() -> AuthorizerRule[TaskListState, Any]:
+    return allow_if(any=[is_owner_or_member, is_app_internal])
+```
+
+**Declare only the arguments the body reads.** The runtime passes
+`context`, `state`, and `request` by keyword; a predicate that never
+looks at `request` simply omits it and lets `**kwargs: Any` absorb
+it. That is also why `**kwargs` is mandatory — it is what keeps the
+predicate working when the runtime starts passing something new.
+
+When the body _does_ read `request`, declare it. One rule covers
+every method on the Servicer, so what arrives is a union of all of
+their request models — which is common, because restricting the
+internal-only methods means telling the methods apart:
+
+```python
+def task_list_access(
+    *,
+    context: ReaderContext,
+    state: TaskListState | None = None,
+    request: Any = None,
+    **kwargs: Any,
+) -> Authorizer.Decision:
+    # Methods only app-internal code may call.
+    if isinstance(request, (CreateRequest, AcceptTaskRequest)):
+        return errors.Ok() if context.app_internal else errors.PermissionDenied()
+    ...
+```
+
+Annotate it `Any` and narrow with `isinstance`, or spell out the
+union of the request models it actually distinguishes.
+
+**Check that the annotation is actually doing something.** These
+types only bite if mypy can resolve the API package: `mypy_path`
+must include the project-root `api/`, and the "don't check generated
+code" stanza must name `<pkg>.v1.<name>_rbt` rather than
+`<pkg>.v1.*` — a blanket ignore silences your own API module, and
+then `TaskListState` is `Any` and a misspelled field passes a green
+mypy run. See `lifecycle-project-setup.md`.
+
 ## Predicate Signatures
 
 The runtime invokes a predicate with at minimum these keyword args:
 `context` (always a `ReaderContext`), `state` (the actor state, possibly
-`None`), and `request` (the request message, possibly `None`). Always
-declare them as keyword-only and include `**kwargs` so signature
-extensions don't break the predicate.
+`None`), and `request` (the request message, possibly `None`). Declare
+the ones the body reads, keyword-only, and always include `**kwargs`
+so the arguments you didn't declare — and any the runtime adds later
+— land there harmlessly.
 
 ## Order Predicates by Cost in `all`
 
@@ -83,6 +171,21 @@ return allow_if(all=[has_verified_token, expensive_team_check])
 
 # Bad — expensive check runs even when caller isn't authenticated.
 return allow_if(all=[expensive_team_check, has_verified_token])
+```
+
+## The Error Types a Predicate Returns
+
+They come from `rbt.v1alpha1.errors_pb2`; a predicate only ever
+returns `Ok`, `Unauthenticated`, or `PermissionDenied`. The module
+also carries the framework errors a call can abort with, which is
+what a typed error union widens to:
+
+```
+Ok  Unauthenticated  PermissionDenied  NotFound  AlreadyExists
+InvalidArgument  FailedPrecondition  OutOfRange  ResourceExhausted
+DeadlineExceeded  Cancelled  Unavailable  Unimplemented  Internal
+Unknown  DataLoss  Aborted  StateNotConstructed
+StateAlreadyConstructed  UnknownService  UnknownTask  InvalidMethod
 ```
 
 ## Distinguish `PermissionDenied` from `Unauthenticated`

--- a/reboot/plugin/skills/python/references/lifecycle-project-setup.md
+++ b/reboot/plugin/skills/python/references/lifecycle-project-setup.md
@@ -138,7 +138,7 @@ warn_unused_configs = True
 # Find modules in our source tree (and tests). Since `protoc` doesn't
 # generate `__init__.py` files, treat these as explicit package bases:
 #   https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules
-mypy_path = backend/tests:backend/src:backend/api
+mypy_path = backend/tests:backend/src:backend/api:api
 explicit_package_bases = True
 
 # Stricter than the default, but cheap to adhere to and high value.
@@ -157,10 +157,24 @@ ignore_missing_imports = True
 
 # The generated `*_rbt.py` for your API package is not hand-written;
 # don't type-check it (you never edit it anyway). Repeat per package.
-[mypy-<pkg>.v1.*]
+# Name the generated module specifically — a blanket `<pkg>.v1.*`
+# would also silence your own `api/<pkg>/v1/<name>.py`, and with it
+# every state and request model your code is annotated with.
+[mypy-<pkg>.v1.<name>_rbt]
 ignore_errors = True
 ignore_missing_imports = True
 ```
+
+**Both details in that file are load-bearing.** The project-root
+`api/` entry in `mypy_path` is what lets mypy resolve the
+hand-written pydantic API module, and the narrow ignore stanza is
+what stops it being silenced again. Get either wrong and
+`from <pkg>.v1.<name> import <X>State` quietly resolves to `Any`:
+mypy still reports "Success", but every annotation mentioning a
+state or request model checks nothing, and a misspelled field on
+`state` sails through to a test failure. A quick way to confirm the
+config is live: add a bogus attribute access on a state model and
+check that mypy reports `has no attribute`.
 
 ## Always Type-Check What You Write
 

--- a/reboot/plugin/skills/python/references/patterns-common-gotchas.md
+++ b/reboot/plugin/skills/python/references/patterns-common-gotchas.md
@@ -240,3 +240,51 @@ been deployed can make it fail to boot ("Updated state or method
 definitions are not backwards compatible") and get its deploy
 rejected. Read `api-schema-evolution.md` for the rules you must
 follow before changing such an API.
+
+### 20. A `ref()` Belongs to One Context — `MixedContextsError`
+
+**Reusing a ref for many calls on the same context is fine** — hold
+it in a local and call it as often as you like:
+
+```python
+task_list = TaskList.ref(list_id)
+await task_list.add_task(context, title="Milk")
+await task_list.toggle_task(context, task_id=task_id)
+snapshot = await task_list.get(context)      # All fine.
+```
+
+What is not allowed is carrying that same ref object across to a
+**different** context. `Type.ref(id)` binds to the first `Context`
+it is used with (it carries that context's idempotency manager), so
+a ref stashed on `self`, hoisted to a module constant, or shared
+between two test contexts raises `MixedContextsError` — on readers
+as well as mutations, and regardless of the id being identical:
+
+```python
+# Wrong — one ref object, two contexts.
+shared = TaskList.ref(list_id)
+await shared.get(alice)
+await shared.get(alice2)     # MixedContextsError, even for the
+                             # same user and the same list id.
+
+# Right — a fresh ref per context; `ref()` is cheap.
+await TaskList.ref(list_id).get(alice)
+await TaskList.ref(list_id).get(alice2)
+```
+
+The error names the fix directly: "Instead create a new
+`WeakReference` for every `Context`."
+
+### 21. The State Type Named `User` Is Auto-Constructed
+
+A state type literally named `User` is special: when
+`Application(oauth=...)` is configured, Reboot auto-constructs one
+`User` actor per signed-in identity, whose state id **is** the
+`context.auth.user_id`, on first access. Do not write a sign-up
+method that creates it, do not pass an id to `useUser()` in the
+browser, and do not construct it in tests — impersonating a user
+with `await rbt.create_external_context_as(name, user_id)` is enough
+for `User.ref(user_id)` to resolve. The auto-construction happens
+only under `oauth=`; an app with a `User` type and no `oauth=` fails
+to start. Other state types are constructed explicitly, by their
+factory `create`.

--- a/reboot/plugin/skills/python/references/patterns-idempotency.md
+++ b/reboot/plugin/skills/python/references/patterns-idempotency.md
@@ -72,3 +72,47 @@ Reboot may retry transactions internally. Don't write transaction code
 that depends on running exactly once — every action inside a transaction
 should be idempotent at the level of "the same input produces the same
 state change once committed".
+
+## Uncertain Mutations — `IdempotencyUncertainError`
+
+When a mutation call raises, the client has to decide whether the
+mutation actually happened on the server. It can only be sure when
+the exception is **definitively from the backend**: an `Aborted`
+carrying an error the method _declared_. Those are recoverable — a
+caller can catch one and the transaction still commits.
+
+Anything else (a transport failure, a cancellation, an undeclared
+error) leaves the client genuinely unable to tell, so it marks the
+context as having an **uncertain mutation**. The next mutation you
+make from that same context _without_ an idempotency key then
+fails with `IdempotencyUncertainError`:
+
+> Because we don't know if the mutation from calling `X` of state
+> `'…'` failed or succeeded AND you've made some NON-IDEMPOTENT
+> mutations we can't reliably determine whether or not the call to
+> `Y` … is due to a retry which may cause an undesired mutation
+
+It is not complaining about the call it refused — it is refusing
+because an _earlier_ call left the context uncertain.
+
+Two consequences worth knowing before you meet them:
+
+- **Asserting a declared error is safe.** A test that does
+  `with self.assertRaises(TaskList.AddTaskAborted)` on a method
+  that declares `QuotaExceededError` creates no uncertainty, and
+  the context stays usable for the assertions that follow.
+- **Retrying a mutation yourself requires an idempotency key.**
+  Any hand-written retry loop, and any mutation issued after a
+  cancelled or transport-failed one, must carry
+  `.idempotently("alias")` or an explicit `key=`:
+
+  ```python
+  await TaskList.ref(list_id).idempotently("Add the first task").add_task(
+      context, title="Milk",
+  )
+  ```
+
+  The alias must be unique within the lifetime of the context —
+  reusing one is how you tell Reboot "this is the same logical
+  mutation", which is exactly right for a retry and exactly wrong
+  for two different additions.

--- a/reboot/plugin/skills/python/references/react-generated-client.md
+++ b/reboot/plugin/skills/python/references/react-generated-client.md
@@ -1,0 +1,124 @@
+---
+title: The Generated React Client Contract
+impact: HIGH
+impactDescription: The exact hook, mutator, and error shapes `rbt generate --react=` emits — identical for web apps and MCP chat apps
+tags: react, hooks, generated, codegen, errors, typescript
+---
+
+## The Generated React Client Contract
+
+`rbt generate --react=<dir>` emits the same client for every surface,
+so this contract holds whether the component renders in a browser SPA
+or inside an MCP host. What differs between surfaces — where the
+files live, how the backend URL is found, how a user signs in — is in
+the skill you are building with:
+[`web-app/references/react-client.md`](../../web-app/references/react-client.md)
+or
+[`chat-app/references/react-scaffolding.md`](../../chat-app/references/react-scaffolding.md).
+
+**Do not read the generated `*_rbt_react.ts` to rediscover any of
+this.** It runs to tens of thousands of lines, and every one you open
+is re-sent on every later turn.
+
+## What Is Emitted, per State Type
+
+For a state type `Foo`:
+
+```ts
+// Two overloads. With an id, the handle directly; without one, the
+// default-id form (the signed-in user, or the id the MCP session or
+// a URL parameter resolves to).
+export function useFoo(args: { id: string }): UseFooApi;
+export function useFoo(args?: undefined): {
+  foo: UseFooApi | undefined;      // named after the state type
+  isLoading: boolean;
+};
+
+export interface UseFooApi {
+  state_id: string;                // the resolved id
+  mutators: FooMutators;
+  idempotently: (args: { key: string }) => FooIdempotently;
+
+  // One `use<Reader>` per Reader method. `partialRequest` is
+  // optional and partial — every field has a default.
+  useBar(partialRequest?: Foo.PartialBarRequest): {
+    response: Foo.BarResponse | undefined;
+    isLoading: boolean;
+    aborted: FooBarAborted | undefined;
+  };
+
+  // One per mutation, callable straight off the handle.
+  baz(
+    partialRequest?: Foo.PartialBazRequest,
+    options?: { metadata?: any; idempotencyKey?: string },
+  ): Promise<ResponseOrAborted<Foo.BazResponse, FooBazAborted>>;
+}
+
+// Per method, a typed error union you can switch on.
+export type FooBazAbortedError = /* your declared errors | framework errors */;
+export class FooBazAborted extends reboot_api.Aborted { /* .error, .message */ }
+```
+
+## Naming Rules
+
+Write the call before you read anything:
+
+- Python snake_case → TypeScript camelCase, for fields and methods
+  (`from_index` → `fromIndex`, `open_task_count` → `openTaskCount`).
+- A mutation's argument type is `Partial<Method>Request`; request and
+  response types are Zod-validated.
+- A method's failure type is `<Type><Method>Aborted`, and
+  `aborted.error.type` is the Python error class's name.
+
+## Readers Return Three Fields, Not Two
+
+`response`, `isLoading`, **and** `aborted`. A reader can abort — a
+denied `authorizer()`, for instance — and that surfaces as `aborted`
+rather than by throwing.
+
+Guard on `response !== undefined` before touching data: it is the
+only one of the three that narrows `T | undefined`. Use `isLoading`
+for connection state. They diverge — an aborted reader is
+`!isLoading` with no `response`, a reconnect is `isLoading` with a
+stale `response` — and transport disconnects auto-reconnect without
+surfacing as `aborted`, so don't build an online/offline indicator
+out of it.
+
+## Mutations Never Throw
+
+They resolve to `{ response, aborted }`. A `try/catch` around one
+catches nothing and the failure disappears silently. Branch on
+`aborted`:
+
+```tsx
+const { aborted } = await foo.baz({ title });
+if (aborted !== undefined) {
+  // `aborted.error.type` is the Python error class's name.
+  return show(aborted);
+}
+```
+
+## Hook IDs Must Be Real on Every Render
+
+An explicit-id hook is not SWR-style: there is no "pass `undefined`
+to skip" mode. `id: ''` throws
+`state ID must have a length of at least 1`, and `id: undefined`
+throws inside `stateIdToRef`. Identity often resolves
+asynchronously, so the fix is **not** a placeholder id —
+`useFoo({ id: id || '__none__' })` makes every loading session
+subscribe to the same shared actor. Don't mount the component until
+the id is real: guard at the parent and pass a guaranteed-real id
+down.
+
+## Live Updates Are Free
+
+Reader hooks are push-based subscriptions. When any session mutates
+the state, every mounted reader re-renders with the new response —
+no polling, no refetch call, no transport code of your own.
+
+The transport underneath is chosen for you: gRPC server-streaming
+over `https:`, and a WebSocket multiplex otherwise, which is what a
+local `http://` dev server uses. It matters only when you are
+reading a network trace — and because cross-origin WebSocket frames
+carry no cookies, which is why the session JWT rides in the request
+payload rather than in a `Cookie` header.

--- a/reboot/plugin/skills/python/references/servicer-constructor.md
+++ b/reboot/plugin/skills/python/references/servicer-constructor.md
@@ -95,3 +95,10 @@ async def sign_up(
 `Account.open(context, id)` here is the constructor (the `open` method
 declared `factory=True`) and returns the actor reference plus the
 response (or `None` when `response=None`).
+
+## See Also
+
+- `api-methods.md` — "The Servicer Signature Each Declaration
+  Obliges": the exact shape codegen requires for a factory method,
+  including the `request=None` / `response=None` variants. Read it
+  instead of the generated `*_rbt.py`.

--- a/reboot/plugin/skills/python/references/servicer-reader.md
+++ b/reboot/plugin/skills/python/references/servicer-reader.md
@@ -45,11 +45,12 @@ class ChatRoomServicer(ChatRoom.Servicer):
 
 ## Method Signature Matches the API File
 
-The Servicer method name matches the entry name in the
-`Methods(...)` block exactly. Arguments are `(self, context)` when
-`request=None`, or `(self, context, request)` when a request type
-was bound, and the return type is the declared response (`None` if
-`response=None`).
+The signature codegen obliges — the base class to subclass, the
+`request=None` / `response=None` variants, and the two lookalike
+shapes you will find if you grep the generated `*_rbt.py` — is in
+`api-methods.md` ("The Servicer Signature Each Declaration
+Obliges"). Reading it is cheaper than opening the generated file,
+and complete.
 
 ## Readers Run Concurrently
 

--- a/reboot/plugin/skills/python/references/servicer-transaction.md
+++ b/reboot/plugin/skills/python/references/servicer-transaction.md
@@ -157,6 +157,10 @@ orchestration calls where the caller only needs success/failure
 
 ## See Also
 
+- `api-methods.md` — "The Servicer Signature Each Declaration
+  Obliges": the exact shape codegen requires, including the
+  `request=None` / `response=None` variants. Read it instead of
+  the generated `*_rbt.py`.
 - `rpc-refs.md` — `self.ref().state_id` (not `self.state_id`).
 - `rpc-calls.md` — kwargs convention; `await ref.method(context, k=v)`.
 - `rpc-forall.md` — `Service.forall(ids).method(context, ...)` for

--- a/reboot/plugin/skills/python/references/servicer-workflow.md
+++ b/reboot/plugin/skills/python/references/servicer-workflow.md
@@ -1502,6 +1502,9 @@ wraps the underlying model call in `at_least_once` for you. The
 
 ## Related
 
+- `api-methods.md` — "The Servicer Signature Each Declaration
+  Obliges": the exact shape codegen requires, `@classmethod` and
+  `cls` included. Read it instead of the generated `*_rbt.py`.
 - `agent-pydantic-ai.md` / `agent-tools.md` — backend LLM calls and
   AI agents via the durable Reboot `Agent`.
 - `api-methods.md` — the `Workflow(...)` factory and `errors=[...]`.

--- a/reboot/plugin/skills/python/references/servicer-writer.md
+++ b/reboot/plugin/skills/python/references/servicer-writer.md
@@ -132,6 +132,10 @@ async def increment(
 
 ## See Also
 
+- `api-methods.md` — "The Servicer Signature Each Declaration
+  Obliges": the exact shape codegen requires, including the
+  `request=None` / `response=None` variants. Read it instead of
+  the generated `*_rbt.py`.
 - `rpc-refs.md` — `self.ref().state_id` (not `self.state_id`) for this
   actor's ID; `self.ref().schedule(...)` for self-scheduling.
 - `rpc-calls.md` — kwargs convention for calling other actors.

--- a/reboot/plugin/skills/python/references/testing-external-context.md
+++ b/reboot/plugin/skills/python/references/testing-external-context.md
@@ -139,6 +139,38 @@ with self.assertRaises(Aborted):
     await other_cart.get_cart(other_context)
 ```
 
+## Asserting a Live Update — `reactively()`
+
+A "another session sees the change without refreshing" story is
+tested with `reactively()`, the same push-based subscription the
+generated React hooks use. `Type.ref(id).reactively().<reader>(context)`
+returns an **async iterator** that yields a fresh response on every
+state change; `anext()` pulls the next one. Never poll in a loop
+with `asyncio.sleep` — that tests the sleep, not the reactivity.
+
+```python
+# The "other browser session" subscribes...
+subscription = TaskList.ref(list_id).reactively().get(bob)
+first = await asyncio.wait_for(anext(subscription), timeout=10)
+self.assertEqual(first.tasks, [])
+
+# ...another session writes...
+await TaskList.ref(list_id).add_task(alice, title="Milk")
+
+# ...and the subscription is pushed the update.
+while True:
+    update = await asyncio.wait_for(anext(subscription), timeout=10)
+    if len(update.tasks) == 1:
+        break
+self.assertEqual(update.tasks[0].title, "Milk")
+```
+
+Two details that make the difference between a passing and a
+flaky test: always wrap `anext()` in `asyncio.wait_for` so a
+missing update fails fast instead of hanging the suite, and loop
+until the state you expect rather than asserting on the very next
+yield — a subscription may deliver an intermediate snapshot first.
+
 ## Waiting for Spawned Tasks and Workflows
 
 When a method spawns a task (via `schedule(...).method(context)`

--- a/reboot/plugin/skills/python/references/testing-harness.md
+++ b/reboot/plugin/skills/python/references/testing-harness.md
@@ -266,3 +266,83 @@ This is exactly why "write tests for each user story before
 handing the app off" is in the `chat-app` and `web-app` build
 flows: the tests catch contract bugs that a manual click-through
 won't surface for several minutes.
+
+## Asserting a Typed Error — and Keeping `mypy` Happy
+
+A method that declares `errors=[QuotaExceededError, ...]` raises
+`<Type>.<Method>Aborted` whose `.error` is the typed error. Two
+things trip people up:
+
+1. The generated `Aborted` type is per-method:
+   `TaskList.AddTaskAborted`, not a bare `Aborted`.
+2. `.error` is typed as a **union** of your declared errors plus
+   every framework error (`Cancelled`, `PermissionDenied`,
+   `Unknown`, …). `mypy` therefore rejects `error.limit` with
+   `Item "PermissionDenied" of "QuotaExceededError | Cancelled | ..." has no attribute "limit"` until you narrow it.
+
+```python
+with self.assertRaises(TaskList.AddTaskAborted) as caught:
+    await TaskList.ref(list_id).add_task(alice, title="one too many")
+
+error = caught.exception.error
+assert isinstance(error, QuotaExceededError)  # Narrows the union.
+self.assertEqual(error.limit, 10)
+```
+
+`unittest`'s `assertIsInstance` checks at runtime but does **not**
+narrow for `mypy`; a plain `assert isinstance(...)` does both. Use
+the `assert` form, or pair the two.
+
+## Racing Two Mutations in One Test
+
+A concurrency test issues both calls at once and asserts exactly one
+survives. Two rules make it work:
+
+- **One external context per concurrent caller.** Contexts are not
+  safe to use from two places at once, and a `ref()` is bound to
+  the context that first used it (`MixedContextsError`). Create a
+  second context for the same user id when a single user races
+  themselves from two sessions.
+- **Gather with `return_exceptions=True`**, then partition — the
+  loser raises, and letting `gather` propagate it would hide the
+  winner.
+
+- **Set up a state where exactly one call can succeed.** Two
+  concurrent calls that are both individually legal both succeed —
+  that tests nothing. The test needs a rule that only one of them
+  can satisfy: the last slot under a quota, the last item in stock,
+  a balance that covers one of the two transfers.
+
+```python
+# Precondition: the rule allows 10 open tasks, and 9 already exist,
+# so exactly one of the two racing calls below can be allowed.
+for i in range(9):
+    await TaskList.ref(list_a).add_task(self.alice, title=f"t{i}")
+
+alice2 = await self.rbt.create_external_context_as(
+    name=f"alice2-{self.id()}", user_id=ALICE,
+)
+results = await asyncio.gather(
+    TaskList.ref(list_a).add_task(self.alice, title="race-a"),
+    TaskList.ref(list_b).add_task(alice2, title="race-b"),
+    return_exceptions=True,
+)
+failures = [r for r in results if isinstance(r, BaseException)]
+self.assertEqual(len(results) - len(failures), 1)
+self.assertIsInstance(failures[0], TaskList.AddTaskAborted)
+
+# And the invariant actually held — not just "one call raised".
+profile = await User.ref(ALICE).profile(self.alice)
+self.assertEqual(profile.open_task_count, 10)
+```
+
+Assert the invariant, not only the exception. A test that checks
+"one of them failed" passes even if the winner corrupted the
+counter on the way through.
+
+Reboot serializes writers on the same actor and rolls transactions
+back all-or-nothing, so routing the shared invariant (a counter, a
+quota, a balance) through **one** actor is what makes "exactly one
+wins" true. If the invariant is spread across two actors with no
+transaction covering both, the race is genuinely lossy and no test
+setup will fix it.

--- a/reboot/plugin/skills/python/references/testing-project-setup.md
+++ b/reboot/plugin/skills/python/references/testing-project-setup.md
@@ -61,11 +61,21 @@ needs a `pip install -e .`:
 pythonpath=
   src/
   api/
+  ../api/
 ```
+
+**Three entries, not two.** `src/` and `api/` cover your servicers
+and the generated `_rbt` modules, but tests also import the
+hand-written API definition itself — the typed errors and models —
+as `from <pkg>.v1.<name> import QuotaExceededError`, and that module
+lives in the project-root `api/` directory, one level up from
+`backend/`. Leave `../api/` out and the suite fails at import with
+`ModuleNotFoundError: No module named '<pkg>.v1.<name>'`, which
+looks like a codegen failure but is a path problem.
 
 If the layout uses `backend/src` from the project root instead of
 running pytest from `backend/`, adjust the paths accordingly (e.g.
-`pythonpath = backend/src backend/api`).
+`pythonpath = backend/src backend/api api`).
 
 ## `conftest.py` — Only When Needed
 

--- a/reboot/plugin/skills/upgrade/migrations/next/mypy-api-package-and-vite-host.md
+++ b/reboot/plugin/skills/upgrade/migrations/next/mypy-api-package-and-vite-host.md
@@ -1,0 +1,60 @@
+## `mypy` was skipping the API definition; the Vite dev server binds IPv6-only
+
+Two configuration files that earlier project templates generated are
+subtly wrong. Neither failure is visible: the first reports success
+while checking nothing, the second starts a server the browser cannot
+reach.
+
+### 1. Make `mypy` actually check the API definition
+
+Look at the project-root `.mypy.ini`. Two things need to be true, and
+in older projects neither is:
+
+- `mypy_path` must include the project-root `api/` directory — the
+  one holding the hand-written pydantic API definition, not just the
+  generated `backend/api/`. Append `:api` to the existing value, e.g.
+  `mypy_path = backend/tests:backend/src:backend/api:api`.
+- The "don't check generated code" stanza must name the generated
+  module only. If the file has a blanket
+  `[mypy-<pkg>.v1.*]`, narrow it to `[mypy-<pkg>.v1.<name>_rbt]`,
+  where `<name>` is the API definition's module name (the file under
+  `api/<pkg>/v1/`). Repeat per API package.
+
+Together these two mistakes made every import of a state or request
+model — `from <pkg>.v1.<name> import <X>State` — resolve to `Any`.
+Any annotation mentioning one checked nothing, and a misspelled field
+on `state` passed a green `mypy` run.
+
+To confirm the fix is live, temporarily add a bogus attribute access
+on a state model (e.g. `state.no_such_field_xyz` in a servicer or
+authorizer predicate) and run `mypy` from the project root: it must
+report `has no attribute`. Remove the bogus line afterwards.
+
+**Expect newly-reported errors.** Code that was never type-checked is
+now checked for the first time, so this can surface real mistakes.
+Fix them rather than re-widening the ignore stanza.
+
+### 2. Let the browser reach the Vite dev server
+
+Applies to apps with a standalone web frontend (a `web/`, or whatever
+directory `generate --react=` points into, served by Vite).
+
+If `vite.config.ts` has no `server.host`, add one:
+
+```ts
+export default defineConfig({
+  // ...existing plugins/resolve config...
+  server: {
+    // Listen on every interface. Vite's default is `localhost`,
+    // which on modern Node resolves to IPv6 `[::1]` only; a
+    // forwarded port (Codespaces, VS Code remote, a dev VM, a
+    // tunnel) connects over IPv4 `127.0.0.1` and gets connection
+    // refused.
+    host: true,
+    port: parseInt(process.env.PORT || "5173", 10),
+  },
+});
+```
+
+Without it `npm run dev` prints a URL and logs no error, but the page
+is unreachable from a browser on the other side of a forwarded port.

--- a/reboot/plugin/skills/web-app/SKILL.md
+++ b/reboot/plugin/skills/web-app/SKILL.md
@@ -87,6 +87,17 @@ as MCP).
 > (anything that is not a Reboot-minted access JWT) falls
 > through to yours.
 
+The imports, so you don't have to go looking for them:
+
+```python
+from reboot.aio.applications import Application
+from reboot.aio.auth.oauth_providers import (
+    Development,
+    Google,                       # or GitHub, Auth0, …
+    OAuthProviderByEnvironment,
+)
+```
+
 Recommended sequence:
 
 1. **Early development (no provider chosen yet):** configure
@@ -107,77 +118,51 @@ Recommended sequence:
    `python/references/servicer-authorizer.md`,
    `python/references/auth-allow-if.md`, and
    `python/references/auth-built-in-predicates.md`. The
-   provider-selection rules are identical to MCP chat apps —
-   load the
+   The providers and what each needs:
+
+   All arguments are keyword-only.
+
+   | provider        | required arguments                        |
+   | --------------- | ----------------------------------------- |
+   | `Development()` | none — dev only, sign in as any identity  |
+   | `Anonymous()`   | none — every visitor is a fresh identity  |
+   | `Google(...)`   | `client_id=`, `client_secret=`            |
+   | `GitHub(...)`   | `client_id=`, `client_secret=`            |
+   | `Auth0(...)`    | `domain=`, `client_id=`, `client_secret=` |
+   | `Ory(...)`      | `domain=`, `client_id=`, `client_secret=` |
+
+   The registered providers (everything but `Development` and
+   `Anonymous`) also take `scopes=`, `claims=`, and
+   `store_tokens=`; register `/__/oauth/callback` as the redirect
+   URI with the provider.
+
+   Add `claims=[...]` when you need identity fields such as the
+   user's email, and `store_tokens=True` only when you will call
+   that provider's own API as the user. **Choose deliberately
+   before real users exist**: `context.auth.user_id` is namespaced
+   per provider, so switching providers after launch strands every
+   existing user's state. Only reach for
    [chat-app/references/auth-oauth-providers.md](../chat-app/references/auth-oauth-providers.md)
-   reference for the per-provider details (client IDs, scopes,
-   `store_tokens=True`, requesting identity claims like the
-   user's email via `claims=`, the user-ID-namespace gotcha when
-   switching providers post-launch). In unit tests, keep
+   if you need to write a custom provider or debug a specific
+   provider's flow. In unit tests, keep
    `token_verifier=<your IdP verifier>` exactly as in production —
    the test harness's OAuth server verifies the impersonation token
    minted by `await rbt.create_external_context_as(name, user_id)`,
    and a custom bearer a test constructs by hand still hits your IdP
    verifier; the authorizer rules run for real either way.
+
 3. **Public, unauthenticated endpoints** (health checks, public
    sign-up, public catalog reads): mark these explicitly with
    `allow()`. That's the one legitimate use.
 
-### Feeding the user's identity into hooks — never fabricate an id
+### Feeding the user's identity into hooks
 
-With `Application(oauth=...)`, the signed-in user's own state
-needs no id-threading at all: call the `User` hook with **no
-arguments** and branch on its `{ user, isLoading }` shape (see
-"Browser-side wiring (React)" below); the signed-in user's id —
-for passing into backend calls or other components — is
-`user.state_id`.
-
-An **explicit-id** call (`use<Type>({ id })`) needs a **real,
-non-empty actor id on every render**. It is not SWR-style: there
-is no "pass `null`/`undefined` to skip the subscription" mode. A
-falsy id is a hard throw during render, not a paused hook —
-`id: ''` throws `state ID must have a length of at least 1` and
-`id: undefined` throws a `TypeError` inside `stateIdToRef`. Either
-one crashes the component.
-
-The trap: browser identity resolves **asynchronously** (the
-`/__/oauth/whoami` probe under `oauth=`, or an external IdP like
-Auth0/Firebase under `token_verifier=`), so on the first renders
-you have no user id yet. Do **not** dodge the throw by
-fabricating a placeholder — `useUser({ id: userId || '__no-user__' })`
-is wrong. An actor id is a **global key**, so every loading session
-subscribes to the same shared `__no-user__` actor, it's one
-missed write-guard away from cross-user state, and the placeholder
-addresses nothing — it just silences the crash.
-
-Since an explicit-id hook can't be told "no id" and can't be
-called conditionally (React's rules of hooks), the fix is to **not
-mount the component that calls the hook until you have the real
-id**. Guard at the parent and pass a guaranteed-real id down. With
-`oauth=` that guard is the no-arguments `useUser()` pattern from
-"Browser-side wiring (React)" below — inside the signed-in
-subtree, `user.state_id` is guaranteed real. With an external IdP
-the shape is the same:
-
-```tsx
-function UserHome() {
-  const { user, isAuthenticated, isLoading } = useAuth0();
-  if (isLoading) return <Spinner />;
-  if (!isAuthenticated || !user?.sub) return <LoginPrompt />;
-  // From here, user.sub is guaranteed present and non-empty.
-  return <UserView userId={user.sub} />;
-}
-
-function UserView({ userId }: { userId: string }) {
-  // Hook always runs, always with a real, per-user id.
-  const { create } = useUser({ id: userId });
-  // ...
-}
-```
-
-No placeholder, no fake actor, no `userId && create(...)` guards
-scattered around mutations — the hook simply never runs until the
-key is real.
+With `Application(oauth=...)` the signed-in user's own state needs
+no id-threading: call the `User` hook with **no arguments**. For
+explicit-id hooks the rule is that the id must be real on every
+render — never a placeholder — which is covered with the rest of
+the hook mechanics in
+[`references/react-client.md`](references/react-client.md).
 
 ### Calling external APIs on the user's behalf
 
@@ -203,59 +188,68 @@ same recipe.
 
 ### Browser-side wiring (React)
 
-Wrap your app in `<RebootClientProvider>` and branch on the
-generated `useUser()` hook for the `User` state type — the same
-hook MCP-embedded UIs use. Called with no id, `useUser()` returns
-`{ user, isLoading }`: `isLoading` is true while the session probe
-(`/__/oauth/whoami`) is in flight, then `user` is the handle once
-signed in or `undefined` when signed out. Pass the resolved `user`
-handle to your signed-in subtree and read its id from
-`user.state_id`:
+All of it — the provider (and the `url` it must be given), the
+generated hook surface, sign-in/sign-out, reading typed errors, and
+why a hook's `id` must be real on every render — is in
+[`references/react-client.md`](references/react-client.md). Read it
+at the frontend step; don't reconstruct it from memory here.
 
-```tsx
-import {
-  RebootClientProvider,
-  useSignIn,
-  useSignOut,
-} from "@reboot-dev/reboot-react";
-import { UseUserApi, useUser } from "./gen/your_api/v1/your_api_rbt_react";
+## Which References to Read, and When
 
-function App() {
-  const { user, isLoading } = useUser();
-  const signIn = useSignIn();
-  const signOut = useSignOut();
-  if (isLoading) {
-    return <Spinner />;
-  }
-  if (user === undefined) {
-    return <button onClick={() => signIn()}>Sign in</button>;
-  }
-  return (
-    <>
-      <button onClick={() => signOut()}>Sign out</button>
-      <YourSignedInApp user={user} />
-    </>
-  );
-}
+Everything you read stays in the conversation and is re-sent on
+every later turn, so **read each reference at the step that needs
+it**, not all of them up front. The tiers below are in build order.
 
-// The signed-in subtree takes the `user` handle directly; read its
-// id from `user.state_id` and its readers/mutators off the handle.
-function YourSignedInApp({ user }: { user: UseUserApi }) {
-  const { response } = user.useWhoami();
-  // ...
-}
+> **Never read `chat-app/references/*` for a web app.** They cover
+> the MCP surface — `UI()` artifacts, the MCPJam inspector, the
+> nested `frontend/mcp/<name>/` Vite output, `mcp=Tool()` markers,
+> popping a widget out into a web app. Reaching into them costs
+> context and produces chat-app-shaped code (`mcp=None` on every
+> method of an app with no MCP surface). The web equivalents are
+> [`references/react-client.md`](references/react-client.md) and the
+> `python` references named below. The single exception is
+> [chat-app/references/auth-oauth-providers.md](../chat-app/references/auth-oauth-providers.md),
+> which is surface-neutral: read it when you pick a real provider.
 
-export default () => (
-  <RebootClientProvider>
-    <App />
-  </RebootClientProvider>
-);
-```
+**Tier 0 — before you write the API definition:**
 
-## Read These From `python` First
+- `python/references/patterns-common-gotchas.md` — recurring trips
+  (`self.ref().state_id`, kwargs convention, a `ref()` belongs to
+  one context, the auto-constructed `User` type, etc.).
+- `python/references/api-pydantic.md` — pydantic API rules (every
+  Field needs a zero-value default; non-Optional `Model`-typed
+  fields can't take defaults).
+- `python/references/api-methods.md` — factory → context type
+  mapping (Reader/Writer/Transaction/Workflow).
+- `python/references/state-collections.md` — when the app has any
+  "list of X" concept.
 
-Before scaffolding, load the references that cover the backend
-mechanics. The patterns in this skill assume you've read them.
+**Tier 1 — before you write the servicer:** the
+`python/references/servicer-*.md` file for each context type you
+actually declared, plus `python/references/api-errors.md` if the
+API declares typed errors, and `rpc-refs.md` / `rpc-calls.md`.
+
+**Tier 2 — before you write the frontend:**
+[`references/react-client.md`](references/react-client.md) for the
+web shell, backend URL, and sign-in, plus
+`python/references/react-generated-client.md` for the generated
+hook/mutation/error shapes.
+
+**Tier 3 — before you write tests:** the three
+`python/references/testing-*.md` files, plus
+`python/references/patterns-idempotency.md` — it explains
+`IdempotencyUncertainError`, which is otherwise the one runtime
+error whose cause is not in any reference you have read.
+
+**Tier 4 — before you run the app:** the
+[`run` skill](../run/SKILL.md).
+
+Read a reference **once**. If you find yourself grepping the
+framework's installed source or a generated file to answer a
+question, see "When the Skills Don't Answer It" below — do not
+explore it in the main conversation.
+
+The rest of this section is what each reference covers.
 
 **Always relevant:**
 
@@ -326,19 +320,44 @@ mechanics. The patterns in this skill assume you've read them.
   → read back + call inside a `Workflow`. Never a plain `str` token
   field.
 
-## Workflow: Plan First, Then Build
+**Browser frontend:**
 
-**Always plan the design and get approval before writing code.** The
-state model is the foundation — getting entities, field types, or
-method types wrong means regenerating everything across the project.
+- [`references/react-client.md`](references/react-client.md) — the
+  `web/` shell (stock Vite config + the two `@reboot-dev` packages),
+  the backend URL (`VITE_REBOOT_URL` — the default detection
+  resolves to Vite's origin, not the backend's), the generated
+  `use<Type>()` hook surface, why mutations return
+  `{ response, aborted }` instead of throwing, and how a typed
+  backend error becomes a message the user sees.
 
-### Plan Phase
+## Never Read Generated or Installed Source in the Main Thread
+
+`*_rbt.py`, `*_rbt_react.ts`, `site-packages/`, `node_modules/`,
+and codegen templates run to tens of thousands of lines. Every one
+you open is re-sent on every remaining turn, which makes reading
+them the most expensive way in the system to learn a fact.
+
+The generated surfaces you actually need are written out in these
+references — the React client in
+[`references/react-client.md`](references/react-client.md), the
+backend shapes in `python/references/`. Use them.
+
+If something genuinely isn't covered, bound the output hard: a
+targeted `grep -n … | head -40`, or `sed -n '<start>,<end>p'` over
+a known range. Never a whole generated file, never an unbounded
+recursive grep.
+
+## Workflow: Settle the Design, Then Build
+
+**Always settle the design before writing code.** The state model
+is the foundation — getting entities, field types, or method types
+wrong means regenerating everything across the project.
+
+### Design Phase
 
 1. Analyze the user's description using the State Model Assessment
    below.
-2. Begin a plan for the user to approve (in Claude Code, enter plan
-   mode; in Codex, present the plan and wait for the go-ahead).
-3. Present the proposed design:
+2. State the design you are about to build:
    - Application types: state shape (fields, types, tags).
    - Method map: which operations, which method type
      (Reader/Writer/Transaction/Workflow).
@@ -346,20 +365,19 @@ method types wrong means regenerating everything across the project.
      each page calls.
    - Auth: anonymous, logged-in, or per-user state? If per-user,
      declare a `User` type for owned data and route through it.
-4. Get user approval before writing any files.
-5. Then execute the Step-by-Step Build Flow.
+3. Then execute the Step-by-Step Build Flow.
 
-For updates to existing apps, still plan: read current state,
-propose changes, confirm, then modify.
+For updates to existing apps, still work the design first: read
+current state, state the changes, then modify.
 
-### Writing the Plan for Human Review
+### Writing the Design for a Human Reader
 
-The plan is read by a **human who has not read the skill files**.
-They are evaluating the design — entities, collections, methods,
+The design is read by a **human who has not read the skill files**.
+They are judging the design — entities, collections, methods,
 routes, auth — not verifying that you followed the skill. Write
-so the plan stands on its own.
+so it stands on its own.
 
-**Don't quote skill-internal terms** when presenting the plan.
+**Don't quote skill-internal terms** when presenting the design.
 They mean nothing outside this skill:
 
 - `Shape A` / `Shape B` / `Shape C` — name the actual data
@@ -408,7 +426,7 @@ Nested model — GOOD:
 > state actors because they have no lifecycle, methods, or auth
 > independent of the Document they belong to.
 
-**Escape hatch.** When the precise type name _is_ what the user
+**Escape hatch.** When the precise type name _is_ what the reader
 needs to see ("I'm proposing `OrderedMap` here, not `list[str]`"),
 name the type — but pair it with the plain-English reason in the
 same sentence. The rule is "no bare jargon", not "no technical
@@ -480,11 +498,15 @@ Before writing code, analyze the user's request:
 │   └── <pkg>/v1/
 │       └── <name>.py        # API definition (pydantic)
 ├── backend/
-│   └── src/
-│       ├── main.py          # Application entrypoint
-│       └── servicers/
-│           └── <name>.py    # Servicer implementation
+│   ├── .pytest.ini          # pythonpath: src/ api/ ../api/
+│   ├── src/
+│   │   ├── main.py          # Application entrypoint
+│   │   └── servicers/
+│   │       └── <name>.py    # Servicer implementation
+│   └── tests/
+│       └── <name>_test.py   # One test per user story
 └── web/
+    ├── .env.development     # VITE_REBOOT_URL=http://localhost:9991
     ├── package.json
     ├── tsconfig.json
     ├── tsconfig.app.json
@@ -511,8 +533,7 @@ Key differences from a `chat-app` layout:
 
 ## Step-by-Step Build Flow
 
-**Only execute after plan approval. All commands run from the
-application directory.**
+**All commands run from the application directory.**
 
 1. Create `.python-version`, `pyproject.toml`, `.rbtrc`, and
    `.mypy.ini` — same shape as in
@@ -535,32 +556,25 @@ application directory.**
 7. Initialize the React app at `web/` with your preferred tool
    (e.g. `npm create vite@latest web -- --template react-ts`) or
    a Reboot-provided template if one exists for plain web apps.
+   Read [`references/react-client.md`](references/react-client.md)
+   now — it has the `package.json` dependency set, the `dedupe`
+   entry the Vite config needs, and `web/.env.development` with
+   `VITE_REBOOT_URL`.
 8. `cd web && npm install` and add the Reboot React client
    package(s) per your project's `package.json`.
 9. `uv run rbt generate` again — the React bindings need
    `node_modules` to resolve types correctly.
-10. Wire `main.tsx` with `RebootClientProvider`, then build `App.tsx`
-    and the page components, calling generated `use<Type>()` hooks
-    for reader subscriptions and mutations. Field-name conversion is
-    Python-snake → TypeScript-camel; request/response types are
-    Zod-validated. A reader hook returns both `isLoading` and
-    `response`: use `isLoading` (the stream's connection state) for
-    loading/disconnected indicators (`!isLoading`, debounced, is a
-    connected/disconnected badge) and `response !== undefined` to
-    guard data access (it's also the only one that narrows
-    `response`'s `T | undefined` type). They diverge: an aborted
-    reader is `!isLoading` with no `response`; a reconnect is
-    `isLoading` with stale `response`. Transport disconnects
-    auto-reconnect and do **not** surface via `aborted`, so don't
-    reach for `aborted` or a heartbeat for an online/offline badge.
-    When a hook's `id` comes from the authenticated user, guard the
-    component so it only mounts once the id is real — see "Feeding
-    the user's identity into hooks" above. Never fabricate a
-    placeholder id to get past the non-empty-id validation.
+10. Build the frontend from
+    [`references/react-client.md`](references/react-client.md): the
+    provider and its `url`, the generated hook/mutator/error
+    declarations, sign-in, and typed errors are all written out
+    there. Write the calls from that reference and do **not** open
+    `web/src/api/**/*_rbt_react.ts` to check them — it is tens of
+    thousands of lines that then ride along on every later turn.
 11. `cd web && npm run build` (sanity check the bundle).
 12. **Write and run backend unit tests covering each user-facing
     user story before handing the app off.** Enumerate the user
-    stories from the plan — every action the user should be able
+    stories from the design — every action the user should be able
     to _do_ in the UI (e.g. "sign up and see my profile",
     "submit the form and see the result on the dashboard",
     "delete an item and have it disappear"). Write one test
@@ -568,7 +582,10 @@ application directory.**
     `backend/tests/<servicer>_test.py`, following the patterns
     in `python/references/testing-project-setup.md`,
     `python/references/testing-harness.md`, and
-    `python/references/testing-external-context.md`. Use one
+    `python/references/testing-external-context.md`. When a test fails
+    for a reason that looks like it is inside the framework, check
+    `python/references/patterns-idempotency.md` and
+    `patterns-common-gotchas.md` before reading `site-packages`. Use one
     `IsolatedAsyncioTestCase`, one external context per test
     (`name=f"test-{self.id()}"`), and
     `Service.ref(id).method(context, ...)` for all calls —

--- a/reboot/plugin/skills/web-app/SKILL.md
+++ b/reboot/plugin/skills/web-app/SKILL.md
@@ -198,7 +198,9 @@ at the frontend step; don't reconstruct it from memory here.
 
 Everything you read stays in the conversation and is re-sent on
 every later turn, so **read each reference at the step that needs
-it**, not all of them up front. The tiers below are in build order.
+it** — not all of them up front — and read each one **once**. The
+groups below are in build order, and each reference appears in
+exactly one of them — the step that needs it.
 
 > **Never read `chat-app/references/*` for a web app.** They cover
 > the MCP surface — `UI()` artifacts, the MCPJam inspector, the
@@ -211,96 +213,52 @@ it**, not all of them up front. The tiers below are in build order.
 > [chat-app/references/auth-oauth-providers.md](../chat-app/references/auth-oauth-providers.md),
 > which is surface-neutral: read it when you pick a real provider.
 
-**Tier 0 — before you write the API definition:**
+**Before the API definition:**
 
 - `python/references/patterns-common-gotchas.md` — recurring trips
   (`self.ref().state_id`, kwargs convention, a `ref()` belongs to
-  one context, the auto-constructed `User` type, etc.).
+  one context, the auto-constructed `User` type, `--name` vs.
+  `--application-name`).
 - `python/references/api-pydantic.md` — pydantic API rules (every
   Field needs a zero-value default; non-Optional `Model`-typed
   fields can't take defaults).
 - `python/references/api-methods.md` — factory → context type
   mapping (Reader/Writer/Transaction/Workflow).
-- `python/references/state-collections.md` — when the app has any
-  "list of X" concept.
-
-**Tier 1 — before you write the servicer:** the
-`python/references/servicer-*.md` file for each context type you
-actually declared, plus `python/references/api-errors.md` if the
-API declares typed errors, and `rpc-refs.md` / `rpc-calls.md`.
-
-**Tier 2 — before you write the frontend:**
-[`references/react-client.md`](references/react-client.md) for the
-web shell, backend URL, and sign-in, plus
-`python/references/react-generated-client.md` for the generated
-hook/mutation/error shapes.
-
-**Tier 3 — before you write tests:** the three
-`python/references/testing-*.md` files, plus
-`python/references/patterns-idempotency.md` — it explains
-`IdempotencyUncertainError`, which is otherwise the one runtime
-error whose cause is not in any reference you have read.
-
-**Tier 4 — before you run the app:** the
-[`run` skill](../run/SKILL.md).
-
-Read a reference **once**. If you find yourself grepping the
-framework's installed source or a generated file to answer a
-question, see "When the Skills Don't Answer It" below — do not
-explore it in the main conversation.
-
-The rest of this section is what each reference covers.
-
-**Always relevant:**
-
-- `python/references/patterns-common-gotchas.md` — recurring trips
-  (`self.ref().state_id`, kwargs convention, `--name` vs.
-  `--application-name`, etc.).
-- `python/references/api-pydantic.md` — pydantic API rules (every
-  Field needs a zero-value default; non-Optional `Model`-typed
-  fields can't take defaults).
-
-**Defining the API:**
-
-- `python/references/api-methods.md` — factory → context type
-  mapping (Reader/Writer/Transaction/Workflow).
-- `python/references/api-errors.md` — typed errors.
-- `python/references/state-collections.md` — **always read when
-  the app has any "list of X" concept.** Decides whether each X
-  should be its own state `Type` (most of the time, yes) and picks
-  between in-state `list[Sub]`, in-state `list[str]` of foreign
-  IDs, or an `OrderedMap` of foreign IDs. The trap is
-  defaulting to `list[Todo]`/`list[Document]`/etc. on one parent
-  for entity collections — see Step 1 of that reference.
+- `python/references/api-errors.md` — typed errors, when the API
+  declares any.
+- `python/references/state-collections.md` — **always read when the
+  app has any "list of X" concept.** Decides whether each X should
+  be its own state `Type` (most of the time, yes) and picks between
+  in-state `list[Sub]`, in-state `list[str]` of foreign IDs, or an
+  `OrderedMap` of foreign IDs. The trap is defaulting to
+  `list[Todo]`/`list[Document]`/etc. on one parent for entity
+  collections — see Step 1 of that reference.
 - `python/references/state-nested-models.md` — the same rule from
   the nested-`Model` angle.
 
-**Implementing Servicers:**
+**Before the project shell** (`.rbtrc`, `pyproject.toml`,
+`.mypy.ini`, `main.py`):
 
-- `python/references/servicer-{reader,writer,transaction,constructor,authorizer}.md` — one per context type.
+- `python/references/lifecycle-{project-setup,rbtrc,application-entry,initialize-hook}.md` — the canonical layout, the CLI flags, the
+  `Application(...)` constructor, the `initialize` hook.
+
+**Before the servicer:**
+
+- `python/references/servicer-{reader,writer,transaction,constructor}.md` — one per context type you actually declared.
 - `python/references/rpc-refs.md` — `self.ref().state_id` (never
   `self.state_id`); `self.ref().schedule(...)`.
-- `python/references/rpc-calls.md` — kwargs not Request wrappers.
+- `python/references/rpc-calls.md` — kwargs, not Request wrappers.
 - `python/references/rpc-constructor-calls.md` —
   `Service.create(context, id)` semantics.
-
-**Workflows:**
-
-- `python/references/servicer-workflow.md` — the single,
-  comprehensive workflow reference. Read it top to bottom: the
-  `@classmethod` / `WorkflowContext` declaration shape, the
-  call-classification decision tree (Reboot scopes vs.
-  `at_least_once` vs. `at_most_once`), `context.loop`, inline state
-  writes,
+- `python/references/servicer-workflow.md` — only when you declared
+  a `Workflow`, and then top to bottom: the `@classmethod` /
+  `WorkflowContext` declaration shape, the call-classification
+  decision tree (Reboot scopes vs. `at_least_once` vs.
+  `at_most_once`), `context.loop`, inline state writes,
   `until` / `until_changes`, and workflow exit semantics.
 
-**Project shell:**
-
-- `python/references/lifecycle-{project-setup,rbtrc,application-entry,initialize-hook}.md` — the canonical layout,
-  the CLI flags, the `Application(...)` constructor, the
-  `initialize` hook.
-
-**Auth (browser users — see "Auth in Web Apps" below for the dev-vs-prod sequence):**
+**Before the authorizers** (browser users — see "Auth in Web Apps"
+above for the dev-vs-prod sequence):
 
 - `python/references/servicer-authorizer.md` — **start here**.
   Explains `oauth=` (the default) vs. `token_verifier=` (the
@@ -320,15 +278,29 @@ The rest of this section is what each reference covers.
   → read back + call inside a `Workflow`. Never a plain `str` token
   field.
 
-**Browser frontend:**
+**Before the frontend:**
 
 - [`references/react-client.md`](references/react-client.md) — the
-  `web/` shell (stock Vite config + the two `@reboot-dev` packages),
-  the backend URL (`VITE_REBOOT_URL` — the default detection
-  resolves to Vite's origin, not the backend's), the generated
-  `use<Type>()` hook surface, why mutations return
-  `{ response, aborted }` instead of throwing, and how a typed
-  backend error becomes a message the user sees.
+  `web/` shell (Vite config, including the `server.host` the browser
+  needs), the backend URL (`VITE_REBOOT_URL` — the default detection
+  resolves to Vite's origin, not the backend's), sign-in/sign-out,
+  and how a typed backend error becomes a message the user sees.
+- `python/references/react-generated-client.md` — what
+  `rbt generate --react=` emits: the `use<Type>()` overloads, the
+  three-field reader return, why mutations resolve to
+  `{ response, aborted }` instead of throwing, the typed error
+  classes, and the snake→camel naming rules.
+
+**Before the tests:** the three `python/references/testing-*.md`
+files, plus `python/references/patterns-idempotency.md` — it
+explains `IdempotencyUncertainError`, which is otherwise the one
+runtime error whose cause is not in any reference you have read.
+
+**Before running the app:** the [`run` skill](../run/SKILL.md).
+
+If you find yourself grepping the framework's installed source or a
+generated file to answer a question, the next section is for you —
+do not explore it in the main conversation.
 
 ## Never Read Generated or Installed Source in the Main Thread
 
@@ -549,7 +521,9 @@ Key differences from a `chat-app` layout:
    marker → context-type rules in
    `python/references/api-methods.md`. Do **not** add `mcp=Tool()`
    or `UI()` — those are chat-app only.
-4. `uv run rbt generate`.
+4. `uv run rbt generate`. Don't read what it wrote: the signature
+   your servicer must match is in `python/references/api-methods.md`
+   ("The Servicer Signature Each Declaration Obliges").
 5. Write the servicer (`backend/src/servicers/<name>.py`) —
    context-type patterns in `python/references/servicer-*.md`.
 6. Write `main.py` — `python/references/lifecycle-application-entry.md`.

--- a/reboot/plugin/skills/web-app/references/react-client.md
+++ b/reboot/plugin/skills/web-app/references/react-client.md
@@ -1,0 +1,200 @@
+---
+title: Wire the Web SPA to the Reboot Backend
+impact: HIGH
+impactDescription: The browser shell, the backend URL, the generated hooks, and how a typed backend error reaches the user
+tags: web-app, react, vite, hooks, errors, RebootClientProvider
+---
+
+## Wire the Web SPA to the Reboot Backend
+
+Everything the standalone browser frontend needs. This is the
+web-app equivalent of the chat-app's scaffolding references —
+**do not read those**: their Vite config, nested
+`frontend/mcp/<name>/index.html` output, and `UI()` machinery are
+MCP-host-specific and do not apply to a web app.
+
+## The `web/` Shell
+
+Stock Vite React-TS scaffolding (`npm create vite@latest web -- --template react-ts`), plus the two Reboot packages. Pin them to
+the same version as the backend's `reboot` dependency:
+
+```json
+{
+  "name": "<app>-web",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build"
+  },
+  "dependencies": {
+    "@reboot-dev/reboot-api": "<same version as `reboot` in pyproject.toml>",
+    "@reboot-dev/reboot-react": "<same version>",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zod": "^4.0.0"
+  }
+}
+```
+
+`vite.config.ts` is the stock config with two additions, both
+load-bearing:
+
+```ts
+export default defineConfig({
+  plugins: [react()],
+  // Two copies of `react` or `zod` — one from the app, one pulled
+  // through the Reboot packages — break hooks and schema identity
+  // checks at runtime.
+  resolve: { dedupe: ["react", "react-dom", "zod"] },
+  server: {
+    // Listen on every interface. Vite's default is `localhost`,
+    // which on modern Node resolves to IPv6 `[::1]` only; a
+    // forwarded port (Codespaces, VS Code remote, a dev VM, a
+    // tunnel) connects over IPv4 `127.0.0.1` and gets connection
+    // refused, so the page is unreachable from the browser even
+    // though the dev server is healthy and logs no error.
+    host: true,
+    port: parseInt(process.env.PORT || "5173", 10),
+  },
+});
+```
+
+Leaving `server.host` out is the single most common reason a
+freshly built app "starts fine" and then won't open: `npm run dev`
+prints a URL, the process is up, and the browser cannot reach it.
+
+## The Backend URL — Set It Explicitly in Dev
+
+`<RebootClientProvider>` with no `url` falls back to detection:
+`window.REBOOT_URL`, then a `?rebootUrl=` query parameter, then
+`window.location.origin`. In development the SPA is served by Vite
+on `:5173` while the backend listens on `:9991`, so the fallback
+resolves to the **wrong** origin — and when even that is
+unavailable the client throws
+`Could not detect Reboot server URL. Ensure the page is served from the Reboot server.`
+
+Pass it explicitly, from an env file:
+
+```
+# web/.env.development
+VITE_REBOOT_URL=http://localhost:9991
+```
+
+`import.meta.env` needs Vite's ambient types or `npm run build`
+fails with `Property 'env' does not exist on type 'ImportMeta'`.
+Stock `create vite` scaffolding includes the file; if you assembled
+`web/` by hand, write it:
+
+```ts
+// web/src/vite-env.d.ts
+/// <reference types="vite/client" />
+```
+
+```tsx
+// web/src/main.tsx
+const REBOOT_URL =
+  (import.meta.env.VITE_REBOOT_URL as string | undefined) ??
+  window.location.origin;
+
+createRoot(document.getElementById("root")!).render(
+  <RebootClientProvider url={REBOOT_URL}>
+    <App />
+  </RebootClientProvider>
+);
+```
+
+The `?? window.location.origin` keeps the production build working
+when the backend serves the built assets from one origin.
+
+## The Generated Client
+
+The hook, mutator, and error declarations `rbt generate --react=`
+emits are identical for every surface, so they live in one place:
+[`python/references/react-generated-client.md`](../../python/references/react-generated-client.md).
+Read it before writing components — it has the `useFoo` overloads,
+`UseFooApi`, the three-field reader return, `ResponseOrAborted`, the
+`<Type><Method>Aborted` error classes, the snake→camel naming rules,
+and why a hook id must be real on every render. Do **not** open
+`web/src/api/**/*_rbt_react.ts` to rediscover them.
+
+What is web-app-specific: the client is created by the
+`<RebootClientProvider url={...}>` above, and the signed-in user's
+handle comes from the no-argument `useUser()` (see "Sign-in and
+Sign-out" below).
+
+## Surfacing a Typed Error to the User
+
+`aborted.error` is a discriminated union — the errors the method
+declared plus the framework's (`PermissionDenied`, `Unknown`, …) —
+tagged by `error.type`, which is the Python error class's name. A
+single translator keeps the switch in one place; every story with
+a "shows a visible error" requirement routes through it:
+
+```ts
+// web/src/errors.ts
+export function friendlyError(aborted: {
+  error: { type: string } & Record<string, unknown>;
+  message: string;
+}): string {
+  switch (aborted.error.type) {
+    case "QuotaExceededError":
+      return `Limit reached (${String(aborted.error.limit)}).`;
+    case "UnknownUserError":
+      return `No user named "${String(aborted.error.username)}".`;
+    case "PermissionDenied":
+      return "You don't have access to do that.";
+    default:
+      return aborted.message || `Something went wrong.`;
+  }
+}
+```
+
+The fields on each error case are exactly the fields declared on
+the pydantic error model in the API definition, camelCased. The
+frontend only _reports_; the backend already refused the operation.
+
+## Sign-in and Sign-out
+
+`useSignIn()` / `useSignOut()` from `@reboot-dev/reboot-react` drive
+the built-in OAuth server mounted at `/__/oauth/*`; call the
+returned function from a button. Session state lives in the
+HttpOnly `rbt_session` cookie, so there is no token to store, and
+`useUser()` reports the result (`user === undefined` when signed
+out).
+
+The whole shape, and the one place the signed-in subtree gets its
+guaranteed-real id:
+
+```tsx
+import {
+  RebootClientProvider,
+  useSignIn,
+  useSignOut,
+} from "@reboot-dev/reboot-react";
+import { UseUserApi, useUser } from "./api/<pkg>/v1/<name>_rbt_react";
+
+function App() {
+  const { user, isLoading } = useUser();
+  const signIn = useSignIn();
+  const signOut = useSignOut();
+  // `isLoading` covers the `/__/oauth/whoami` session probe.
+  if (isLoading) return <Spinner />;
+  if (user === undefined) {
+    return <button onClick={() => signIn()}>Sign in</button>;
+  }
+  return (
+    <>
+      <button onClick={() => signOut()}>Sign out</button>
+      <SignedIn user={user} />
+    </>
+  );
+}
+
+// Mounted only once `user` exists, so `user.state_id` is real and
+// every hook below it can be called with a genuine id.
+function SignedIn({ user }: { user: UseUserApi }) {
+  const { response } = user.useProfile();
+  // ...
+}
+```


### PR DESCRIPTION
I've run the reboot agent on the same prompt a couple of times; the very first run (current main) cost $39 and took 45 min to build. Now we've removed the plan stage and started writing files early which produces still high-quality output (at least on the example I've used). The comparison was done against supabase project ($10 and ~16 min), but supabase didn't end up writing a backend servicer, only sql migration file + web, so arguably we are now on the same stage but with a much bigger skill-set.

With the skill changes I've been able to build the app in ~16 min and ~$12, which is a huge improvement already.

<img width="479" height="113" alt="image" src="https://github.com/user-attachments/assets/504b425c-b105-4a96-afce-85b8ac9c7855" />
