### PR TITLE
Strip a trailing slash from $CLAUDE_PLUGIN_ROOT in auto-approve

### DIFF
--- a/reboot/plugin/hooks/auto-approve.sh
+++ b/reboot/plugin/hooks/auto-approve.sh
@@ -37,7 +37,16 @@
 # Anything not matching exits silently with status 0; Claude Code
 # then falls back to the normal permission prompt.
 
-# No env var ⇒ defer to normal prompt.
+# Adding a local directory as the marketplace source — what
+# `install.sh` does when run from a checkout — leaves a trailing slash
+# on the root. Strip it, so the `"${CLAUDE_PLUGIN_ROOT}/skills/"`
+# prefixes below don't end in `//` and match nothing: the agent
+# normalizes the paths it sends, so nothing can match a `//` prefix.
+CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT%/}"
+
+# No env var ⇒ defer to normal prompt. Also catches a root of `/`,
+# emptied by the strip above, whose `/skills/` prefix would match
+# paths anywhere on the filesystem.
 if [ -z "${CLAUDE_PLUGIN_ROOT}" ]; then
     exit 0
 fi

--- a/tests/reboot/plugin/hooks/auto_approve_test.py
+++ b/tests/reboot/plugin/hooks/auto_approve_test.py
@@ -868,6 +868,28 @@ class AutoApproveTest(unittest.TestCase):
                     f"{actual.value}; stdout={stdout!r}",
                 )
 
+    def test_cases_with_trailing_slash_plugin_root(self) -> None:
+        """Every case must decide the same way when
+        `$CLAUDE_PLUGIN_ROOT` carries a trailing slash, which is what
+        adding a local directory as the marketplace source produces.
+        The paths the agent sends are normalized, so a `//skills/`
+        prefix would match nothing and silently approve nothing."""
+        for label, tool_name, tool_input, expected in CASES:
+            with self.subTest(label=label):
+                stdout = run_hook(
+                    tool_name,
+                    tool_input,
+                    plugin_root=f"{PLUGIN_ROOT}/",
+                )
+                actual = decision_from_stdout(stdout)
+                self.assertEqual(
+                    actual,
+                    expected,
+                    f"{label}: with a trailing slash on the plugin root, "
+                    f"expected {expected.value}, got {actual.value}; "
+                    f"stdout={stdout!r}",
+                )
+
     def test_codex_never_approves(self) -> None:
         """Under Codex, the hook must never emit an `allow` decision.
 


### PR DESCRIPTION
Adding a local directory as the marketplace source -- what `install.sh` does when run from a checkout -- leaves `$CLAUDE_PLUGIN_ROOT` ending in `/`. Every check in the hook builds a `"${CLAUDE_PLUGIN_ROOT}/skills/"` prefix, which then ends in `//`, while the agent normalizes the paths it sends before passing them to the hook. Nothing could match, so auto-approval silently approved nothing and the plugin's own skill steps each raised a permission prompt again.

A git marketplace source resolves to a cache directory with no trailing slash, so installs following the README were unaffected; this hit developers installing from a clone, where the symptom is only the absence of an approval.

Strip one trailing slash before the existing guard rather than after, so a root of `/` empties and defers instead of matching `/skills/` anywhere on the filesystem. The case table now runs a second time against a trailing-slash root, which fails without the strip.