### PR TITLE
local-reboot: print the registry-host env var in the publish message

### DIFF
--- a/reboot/stage_and_publish_local.sh
+++ b/reboot/stage_and_publish_local.sh
@@ -71,6 +71,13 @@ echo "==> Published to local registry."
 echo "Set the following to use your local packages:"
 echo
 echo "  export NPM_CONFIG_REGISTRY='$VERDACCIO_URL'"
+# `always` makes npm rewrite the host AND scheme of lockfile-pinned
+# tarball URLs to the local registry's. npm's default (`npmjs`) swaps
+# only the host and keeps the lockfile's `https`, so it fetches
+# tarballs from `https://localhost:...`, which the registry serves as
+# plain http — failing every download with
+# `ERR_SSL_WRONG_VERSION_NUMBER`.
+echo "  export NPM_CONFIG_REPLACE_REGISTRY_HOST='always'"
 echo "  export UV_FIND_LINKS='$STAGE_DIR/wheels'"
 echo
 echo "Then update:"


### PR DESCRIPTION
Before this commit, using `make local-reboot` would produce instructions that don't work for a plain, local `npm install`. Specifically, the `npm install` would try to use `https://localhost:...` while the local proxy was serving on `http`, not `https`.

This commit adds instructions that cause `npm install` to use `http://localhost:...` instead.