### PR TITLE
Docs for presence

### DIFF
--- a/documentation/docs/library_services/presence.mdx
+++ b/documentation/docs/library_services/presence.mdx
@@ -1,0 +1,488 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# Presence
+
+Tracks which subscribers (e.g. users, browser tabs, or other clients) are
+currently connected, automatically detecting when a connection has dropped.
+
+The library is composed of three servicers:
+- `Presence`: Each `Presence` instance (identified by an `ID`) tracks a set of
+   currently online subscribers. To track online presence in different instances
+   (e.g. multiple chat rooms or shared documents), use a different `ID` for each
+   `Presence` instance.
+- `Subscriber`: Represents an individual client connection.
+- `MousePosition`: Optional servicer for tracking and syncing mouse cursor
+   position in real time.
+
+This library also has build in [React](#react) support so you can quickly drop
+these features into your React app.
+
+
+
+## Imports and set up
+
+To use `Presence`, include its library when starting up your `Application`.
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+from reboot.std.presence.v1.presence import presence_library
+
+async def main():
+    application = Application(
+        servicers=[MyServicer],
+        libraries=[presence_library()],
+    )
+    await application.run()
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+import { presenceLibrary } from "@reboot-dev/reboot-std/presence/v1";
+
+new Application({
+  servicers: [MyServicer],
+  libraries: [presenceLibrary()]
+  initialize,
+}).run();
+```
+  </TabItem>
+</Tabs>
+
+### Authorizer
+
+By default, `Presence` allows all calls coming internally (e.g. from
+your Reboot backend) or externally (e.g. from your React app). However,
+this can be overridden by providing your own
+[authorizer](/learn_more/auth#authorizers).
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+presence_authorizer = Presence.Authorizer(
+    ... # !!! TODO: FILL OUT, also, which of these are actually necessary for react?
+)
+
+subscriber_authorizer = Subscriber.Authorizer(
+    ...
+)
+
+mouse_position_authorizer = MousePosition.Authorizer(
+    ...
+)
+
+application = Application(
+    servicers=[MyServicer],
+    libraries=[presence_library(
+        presence_authorizer=presence_authorizer,
+        subscriber_authorizer=subscriber_authorizer,
+        mouse_position_authorizer=mouse_position_authorizer,
+    )],
+)
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+const presenceAuthorizer = new Presence.Authorizer({
+  ... // !!! TODO: FILL OUT, also, which of these are actually necessary for react?
+});
+
+const subscriberAuthorizer = new Subscriber.Authorizer({
+  ...
+});
+
+const mousePositionAuthorizer = new MousePosition.Authorizer({
+  ...
+});
+
+const application = new Application({
+  servicers: [MyServicer],
+  libraries: [presenceLibrary({
+    presenceAuthorizer,
+    subscriberAuthorizer,
+    mousePositionAuthorizer,
+  })],
+  initialize,
+});
+
+```
+  </TabItem>
+</Tabs>
+
+## React
+
+Once you've [set up](/learn_more/call/from_react) your React app to call
+into your Reboot API, you can use the `Presence` React library to quickly
+add presence tracking in your React app.
+
+First, add `@reboot-dev/reboot-std-api` and
+`@reboot-dev/reboot-std-react` to your `package.json`.
+
+```bash
+!!! TODO: what about reboot-react or reboot-std
+npm install -S @reboot-dev/reboot-std-api
+npm install -S reboot-dev/reboot-std-react
+```
+
+You may also want to, in defining your Reboot application, wish to [override
+the default authorizer](#authorizer).
+
+The [`Presence`](#presence-component) and
+[`MouseTracker`](#mousetracker-component) components allow you to quickly add
+these features to your app. However, you can also call the library
+[methods](#direct-library-usage) directly from React. See [Call your API from
+React](/learn_more/call/from_react) to learn more about how to do this.
+
+### Presence Component
+
+The `Presence` React component is used to
+1. Track the current client who is online, identified by a `subscriberId`.
+2. Receive a list of subscribers by ID who are currently connected.
+
+Place any components that need presence data in a `Presence` component.
+The children components can then call `usePresenceContext()` to get
+the list of online subscribers by ID.
+
+#### Properties of &lt;Presence&gt;
+* `presenceId` is the `string` ID of the `Presence` instance you want to track
+the subscriber for.
+* `subscriberId` is the `string` ID of the `Subscriber` who is connecting.
+
+#### Properties returned from `usePresenceContext()`
+* `subscriberId` is the `string` ID `Subscriber` who is connecting.
+* `subscriberIds` is a `string[]` of `Subscribers` who are connected.
+
+```tsx
+import {
+  Presence,
+  usePresenceContext,
+} from "@reboot-dev/reboot-std-react/presence";
+
+// ...
+
+<Presence id={presenceId} subscriberId={subscriberId}>
+  <SubscriberList />
+</Presence>
+
+// ...
+
+const SubscriberList: FC<{}> = () => {
+  const { subscriberId, subscriberIds } = usePresenceContext();
+
+  return (
+    <ul>
+      {subscriberIds.map((id) => (
+        <li key={id}>{id === subscriberId ? `${id} (you)` : id}</li>
+      ))}
+    </ul>
+  );
+};
+```
+
+### MouseTracker Component
+
+The `MouseTracker` component can be added as a child to the `Presence`
+component to sync mouse positions across clients.
+
+The `arrow` prop defines how the other synchronized cursors will appear.
+
+```tsx
+<Presence id={presenceId} subscriberId={subscriberId}>
+  <MouseTracker
+    style={{
+      width: "400px",
+      height: "250px",
+    }}
+    arrow={<span>↖</span>}
+  />
+</Presence>
+```
+
+
+## Direct Library Usage
+
+If you want to use the `Presence` library directly, such as access the
+information server side, you can call the Reboot methods directly as usual.
+
+### Imports
+
+To use `Presence`, `Subscriber` or `MousePosition` servicers, import them where
+you would like to use it.
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+<!-- MARKDOWN-AUTO-DOCS:START
+(CODE:src=../../../tests/reboot/std/presence/presence_tests.py&lines=11-15) -->
+<!-- The below code snippet is automatically added from ../../../tests/reboot/std/presence/presence_tests.py -->
+
+```py
+from reboot.std.presence.v1.presence import (
+    MousePosition,
+    Presence,
+    Subscriber,
+)
+```
+
+<!-- MARKDOWN-AUTO-DOCS:END -->
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+<!-- MARKDOWN-AUTO-DOCS:START
+(CODE:src=../../../tests/reboot/std/presence/presence_tests.ts&lines=3-5) -->
+<!-- The below code snippet is automatically added from ../../../tests/reboot/std/presence/presence_tests.ts -->
+
+```ts
+import { MousePosition } from "@reboot-dev/reboot-std/presence/mouse_tracker/v1";
+import { Subscriber } from "@reboot-dev/reboot-std/presence/subscriber/v1";
+import { Presence } from "@reboot-dev/reboot-std/presence/v1";
+```
+
+<!-- MARKDOWN-AUTO-DOCS:END -->
+  </TabItem>
+</Tabs>
+
+## Presence Methods
+
+Each `Presence` instance tracks a set of currently online subscribers. You
+can have as many `Presence` instances as you like, each with a unique ID
+(e.g. one per room, channel, or document).
+
+### Getting a reference
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+presence = Presence.ref("my-room")
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+const presence = Presence.ref("my-room");
+```
+  </TabItem>
+</Tabs>
+
+### Subscribe
+
+Register a subscriber as present. The subscriber's [`status()`](#status) must
+already be `present` or you will receive a `FailedPrecondition` error.
+
+If the subscriber disconnects, they will automatically be removed from the list
+of online subscribers.
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+await presence.subscribe(
+    context,
+    subscriber_id="user-abc",
+)
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+await presence.subscribe(context, {
+  subscriberId: "user-abc",
+});
+```
+  </TabItem>
+</Tabs>
+
+### List
+
+Return the IDs of all the subscribers currently connected.
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+response = await presence.list(context)
+print(response.subscriber_ids)
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+const { subscriberIds } = await presence.list(context);
+console.log(subscriberIds);
+```
+  </TabItem>
+</Tabs>
+
+## Subscriber Methods
+
+Each `Subscriber` represents a single connected client.
+
+You may want to use one `Subscriber` per user or per connection. For example,
+if you want to list which users are in a chat room without listing the user
+twice if they are connected via computer or mobile device, use one `Subscriber`
+per user. If instead you want to show the user as appearing 5 times when they
+have 5 browser tabs open to your app, you would want to use one `Subscriber` for
+each of those browser tab connections.
+
+One `Subscriber` can be added to multiple `Presence` instances (e.g. to show
+a user is generally online and in specific chat rooms).
+
+### Getting a reference
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+subscriber = Subscriber.ref("user-abc")
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+const subscriber = Subscriber.ref("user-abc");
+```
+  </TabItem>
+</Tabs>
+
+### Create
+
+Creates the `Subscriber` or ensures that it has already been created.
+This needs to be called before calling [`connect()`](#connect), and it is
+recommended to make this call before any [`connect()`](#connect) attempt.
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+await subscriber.create(context)
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+await subscriber.create(context);
+```
+  </TabItem>
+</Tabs>
+
+
+### Connect
+
+Used to initiate a subscription and detects when the subscriber is no longer
+present.
+
+This method runs indefinitely, that is, it does return. It also requires a
+unique nonce for every call.
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+nonce = uuid.uuid4().hex
+
+# TODO !!! CHECK THIS
+
+# connect() runs indefinitely; run it concurrently with toggle().
+asyncio.gather(
+    subscriber.connect(context, nonce=nonce),
+    subscriber.toggle(context, nonce=nonce),
+)
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+// TODO !!! CHECK THIS
+
+const nonce = uuidv4();
+
+// connect() runs indefinitely; run it concurrently with toggle().
+const abortController = new AbortController();
+Promise.all([
+  subscriber.connect(
+    { signal: abortController.signal },
+    { nonce },
+  ),
+  subscriber.toggle(context, { nonce }),
+]);
+```
+  </TabItem>
+</Tabs>
+
+### Toggle
+
+Required to confirm that [`connect()`](#connect) for a given `nonce` is live.
+The [`status()`](#status) of the `Subscriber` is not set to present *until* `toggle()` call
+is made.
+
+Requires the same `nonce` that was used for the [`connect()`](#connect) call.
+
+See [`connect()`](#connect) for concurrent call example.
+
+### Status
+
+Returns the `status` of the `Subscriber`. `present` is true if any of the
+`Subscriber`'s connections (made via a [`connect()`](#connect) and
+[`toggle()`](#toggle)) are still live. Otherwise returns false.
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+response = await subscriber.status(context)
+print(response.present)  # True if connected
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+const { present } = await subscriber.status(context);
+console.log(present); // true if connected
+```
+  </TabItem>
+</Tabs>
+
+## MousePosition Methods
+
+`MousePosition` is an optional Servicer that stores a client's current mouse
+cursor coordinates.
+
+The easiest way get started using `MousePosition` is to use the same `ID`
+as the `Subscriber`, and to use one `Subscriber` per connection.
+
+### Getting a reference
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+mouse_position = MousePosition.ref("user-abc")
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+const mousePosition = MousePosition.ref("user-abc");
+```
+  </TabItem>
+</Tabs>
+
+### Update
+
+Set the current mouse position.
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+await mouse_position.update(context, left=120, top=240)
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+await mousePosition.update(context, { left: 120, top: 240 });
+```
+  </TabItem>
+</Tabs>
+
+### Position
+
+Returns the current mouse position.
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+response = await mouse_position.position(context)
+print(response.left, response.top)
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+const { left, top } = await mousePosition.position(context);
+console.log(left, top);
+```
+  </TabItem>
+</Tabs>

--- a/documentation/docs/library_services/presence.mdx
+++ b/documentation/docs/library_services/presence.mdx
@@ -43,7 +43,7 @@ import { presenceLibrary } from "@reboot-dev/reboot-std/presence/v1";
 
 new Application({
   servicers: [MyServicer],
-  libraries: [presenceLibrary()]
+  libraries: [presenceLibrary()],
   initialize,
 }).run();
 ```
@@ -52,25 +52,47 @@ new Application({
 
 ### Authorizer
 
-By default, `Presence` allows all calls coming internally (e.g. from
-your Reboot backend) or externally (e.g. from your React app). However,
-this can be overridden by providing your own
-[authorizer](/learn_more/auth#authorizers).
+By default, `Presence` allows internal calls (e.g. from your Reboot backend)
+and external calls with a [verified token](/learn_more/auth#token-verification).
+However, this can be overridden by providing an
+[authorizer rule](/learn_more/auth#authorizer-rules) for all servicers in the
+presence library:
 
 <Tabs groupId="language">
   <TabItem value="python" label="Python" default>
 ```py
-presence_authorizer = Presence.Authorizer(
-    ... # !!! TODO: FILL OUT, also, which of these are actually necessary for react?
+application = Application(
+    servicers=[MyServicer],
+    libraries=[presence_library(
+        authorizer=allow_if(any=[has_verified_token])
+    )],
 )
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```ts
+const application = new Application({
+  servicers: [MyServicer],
+  libraries: [presenceLibrary({
+    authorizer: allowIf({ all: [hasVerifiedToken] })
+  })],
+  initialize,
+});
 
-subscriber_authorizer = Subscriber.Authorizer(
-    ...
-)
+```
+  </TabItem>
+</Tabs>
 
-mouse_position_authorizer = MousePosition.Authorizer(
-    ...
-)
+or by providing specific service [authorizers](/learn_more/auth#authorizers):
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+```py
+presence_authorizer = Presence.Authorizer( ... )
+
+subscriber_authorizer = Subscriber.Authorizer( ... )
+
+mouse_position_authorizer = MousePosition.Authorizer( ... )
 
 application = Application(
     servicers=[MyServicer],
@@ -84,17 +106,11 @@ application = Application(
   </TabItem>
   <TabItem value="typescript" label="TypeScript">
 ```ts
-const presenceAuthorizer = new Presence.Authorizer({
-  ... // !!! TODO: FILL OUT, also, which of these are actually necessary for react?
-});
+const presenceAuthorizer = new Presence.Authorizer({ ... });
 
-const subscriberAuthorizer = new Subscriber.Authorizer({
-  ...
-});
+const subscriberAuthorizer = new Subscriber.Authorizer({ ... });
 
-const mousePositionAuthorizer = new MousePosition.Authorizer({
-  ...
-});
+const mousePositionAuthorizer = new MousePosition.Authorizer({ ... });
 
 const application = new Application({
   servicers: [MyServicer],
@@ -112,17 +128,18 @@ const application = new Application({
 
 ## React
 
-Once you've [set up](/learn_more/call/from_react) your React app to call
-into your Reboot API, you can use the `Presence` React library to quickly
-add presence tracking in your React app.
+The `Presence` library can be easily dropped into your React app to quicklly
+add presence tracking.
 
-First, add `@reboot-dev/reboot-std-api` and
-`@reboot-dev/reboot-std-react` to your `package.json`.
+Once you've [set up](/learn_more/call/from_react) your app to call
+into your Reboot API, install `@reboot-dev/reboot-std`,
+`@reboot-dev/reboot-std-api`, and `@reboot-dev/reboot-std-react` to your
+`package.json`.
 
 ```bash
-!!! TODO: what about reboot-react or reboot-std
+npm install -S @reboot-dev/reboot-std
 npm install -S @reboot-dev/reboot-std-api
-npm install -S reboot-dev/reboot-std-react
+npm install -S @reboot-dev/reboot-std-react
 ```
 
 You may also want to, in defining your Reboot application, wish to [override
@@ -145,7 +162,7 @@ The children components can then call `usePresenceContext()` to get
 the list of online subscribers by ID.
 
 #### Properties of &lt;Presence&gt;
-* `presenceId` is the `string` ID of the `Presence` instance you want to track
+* `id` is the `string` ID of the `Presence` instance you want to track
 the subscriber for.
 * `subscriberId` is the `string` ID of the `Subscriber` who is connecting.
 
@@ -213,7 +230,7 @@ you would like to use it.
 <Tabs groupId="language">
   <TabItem value="python" label="Python" default>
 <!-- MARKDOWN-AUTO-DOCS:START
-(CODE:src=../../../tests/reboot/std/presence/presence_tests.py&lines=11-15) -->
+(CODE:src=../../../tests/reboot/std/presence/presence_tests.py&lines=20-24) -->
 <!-- The below code snippet is automatically added from ../../../tests/reboot/std/presence/presence_tests.py -->
 
 ```py
@@ -228,7 +245,7 @@ from reboot.std.presence.v1.presence import (
   </TabItem>
   <TabItem value="typescript" label="TypeScript">
 <!-- MARKDOWN-AUTO-DOCS:START
-(CODE:src=../../../tests/reboot/std/presence/presence_tests.ts&lines=3-5) -->
+(CODE:src=../../../tests/reboot/std/presence/presence_tests.ts&lines=11-13) -->
 <!-- The below code snippet is automatically added from ../../../tests/reboot/std/presence/presence_tests.ts -->
 
 ```ts
@@ -341,6 +358,7 @@ const subscriber = Subscriber.ref("user-abc");
 Creates the `Subscriber` or ensures that it has already been created.
 This needs to be called before calling [`connect()`](#connect), and it is
 recommended to make this call before any [`connect()`](#connect) attempt.
+It is safe to call this method multiple times.
 
 <Tabs groupId="language">
   <TabItem value="python" label="Python" default>
@@ -358,44 +376,12 @@ await subscriber.create(context);
 
 ### Connect
 
-Used to initiate a subscription and detects when the subscriber is no longer
-present.
+Used to initiate a subscription. This method runs indefinitely and determines
+when the subscriber is no longer present due to a dropped connection (e.g. when
+a user closes the browser tab).
 
-This method runs indefinitely, that is, it does return. It also requires a
-unique nonce for every call.
+See the [example code](#complete-example) below for how to use `connect()`.
 
-<Tabs groupId="language">
-  <TabItem value="python" label="Python" default>
-```py
-nonce = uuid.uuid4().hex
-
-# TODO !!! CHECK THIS
-
-# connect() runs indefinitely; run it concurrently with toggle().
-asyncio.gather(
-    subscriber.connect(context, nonce=nonce),
-    subscriber.toggle(context, nonce=nonce),
-)
-```
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
-```ts
-// TODO !!! CHECK THIS
-
-const nonce = uuidv4();
-
-// connect() runs indefinitely; run it concurrently with toggle().
-const abortController = new AbortController();
-Promise.all([
-  subscriber.connect(
-    { signal: abortController.signal },
-    { nonce },
-  ),
-  subscriber.toggle(context, { nonce }),
-]);
-```
-  </TabItem>
-</Tabs>
 
 ### Toggle
 
@@ -405,7 +391,7 @@ is made.
 
 Requires the same `nonce` that was used for the [`connect()`](#connect) call.
 
-See [`connect()`](#connect) for concurrent call example.
+See the [example code](#complete-example) below for how to use `toggle()`.
 
 ### Status
 
@@ -424,6 +410,97 @@ print(response.present)  # True if connected
 ```ts
 const { present } = await subscriber.status(context);
 console.log(present); // true if connected
+```
+  </TabItem>
+</Tabs>
+
+### Complete Example 
+
+The following is a complete example of how to create and connect a `Subscriber`
+to a `Presence` instance.
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+<!-- MARKDOWN-AUTO-DOCS:START
+(CODE:src=../../../tests/reboot/std/presence/presence_tests.py&lines=71-102) -->
+<!-- The below code snippet is automatically added from ../../../tests/reboot/std/presence/presence_tests.py -->
+
+```py
+connect_failed = False
+
+async def connect():
+    nonlocal connect_failed
+    try:
+        await subscriber_ref.Connect(context, nonce=nonce)
+    except:
+        connect_failed = True
+
+connect_task = asyncio.create_task(connect())
+
+# Retry `Toggle` and `Subscribe` as long as connection hasn't failed.
+attempt_num = 0
+while not connect_failed:
+    try:
+        print(f"Testing attempt: {attempt_num}")
+        await subscriber_ref.idempotently(
+            f"Attempt {attempt_num}",
+        ).Toggle(context, nonce=nonce)
+    except Subscriber.ToggleAborted as aborted:
+        if isinstance(aborted.error, NotFound):
+            print("Retrying Toggle")
+            attempt_num += 1
+            continue
+        raise
+
+    await presence_ref.Subscribe(
+        context, subscriber_id=subscriber_ref.state_id
+    )
+
+    # We've successfully subscribed and don't need to retry!
+    break
+```
+
+<!-- MARKDOWN-AUTO-DOCS:END -->
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+<!-- Based on "Subscriber connect" test in 
+../../../tests/reboot/std/presence/presence_tests.ts
+-->
+```ts
+const nonce = uuidv4();
+let connectFailed = false;
+
+await subscriberRef.idempotently().create(context);
+
+subscriberRef
+  .connect(context, { nonce })
+  .catch((_) => {
+    connectFailed = true;
+  });
+
+let attempt = 0;
+while (!connectFailed) {
+  try {
+    await subscriberRef
+      .idempotently(`attempt-${attempt}`)
+      .toggle(context, { nonce });
+  } catch (e) {
+    if (
+      e instanceof Subscriber.ToggleAborted &&
+      e.error instanceof errors_pb.NotFound
+    ) {
+      attempt++;
+      continue;
+    } else {
+      break;
+    }
+  }
+    
+  await presenceRef.subscribe(context, {
+    subscriberId: subscriberRef.stateId,
+  });
+  break;
+}
 ```
   </TabItem>
 </Tabs>

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -145,6 +145,7 @@ const sidebars = {
         "library_services/mailgun",
         "library_services/oauth_token_manager",
         "library_services/ordered_map",
+        "library_services/presence",
         "library_services/pubsub",
         "library_services/queue",
         "library_services/sorted_map",

--- a/reboot/std/react/presence/index.tsx
+++ b/reboot/std/react/presence/index.tsx
@@ -118,8 +118,9 @@ const MouseArrow: FC<{ id: string; arrow: ReactNode }> = ({ id, arrow }) => {
 
   return (
     <div
-      className="absolute text-black"
+      className="presence-mouse-arrow"
       style={{
+        position: "absolute",
         top: response.top,
         left: response.left,
       }}
@@ -134,7 +135,7 @@ export const MouseTracker: FC<{
   arrow: ReactNode;
   className?: string;
   style?: React.CSSProperties;
-  children: ReactNode;
+  children?: ReactNode;
 }> = ({ arrow, className, style, children }) => {
   const { subscriberId, subscriberIds } = usePresenceContext();
 

--- a/tests/reboot/std/collections/queue/v1/queue_tests.py
+++ b/tests/reboot/std/collections/queue/v1/queue_tests.py
@@ -4,7 +4,7 @@ from reboot.aio.applications import Application
 from reboot.aio.tests import Reboot
 from reboot.protobuf import as_int, as_str, from_int, from_str, pack, unpack
 
-# Import used in Queue documentation, so we want to keep them
+# Import used in Queue documentation, so we want to keep them separate.
 # isort: off
 from reboot.std.collections.queue.v1.queue import Queue
 from reboot.std.item.v1.item import Item

--- a/tests/reboot/std/presence/BUILD.bazel
+++ b/tests/reboot/std/presence/BUILD.bazel
@@ -16,6 +16,7 @@ ts_project(
     name = "presence_tests_ts",
     srcs = [
         "presence_tests.ts",
+        "subscriber_connect.ts",
         ":package.json",
     ],
     declaration = True,
@@ -33,6 +34,8 @@ ts_project(
         "//:node_modules/@reboot-dev/reboot-api",
         "//:node_modules/@reboot-dev/reboot-std",
         "//:node_modules/@types/node",
+        # Required to get uuid package.
+        "//tests/reboot:greeter_js_reboot",
     ],
 )
 

--- a/tests/reboot/std/presence/presence_tests.py
+++ b/tests/reboot/std/presence/presence_tests.py
@@ -14,13 +14,19 @@ from reboot.aio.contexts import ReaderContext
 from reboot.aio.external import ExternalContext
 from reboot.aio.memoize import MemoizeServicer
 from reboot.aio.tests import Reboot
+
+# Import used in Presence documentation, so we want to keep them separate.
+# isort: off
+from reboot.std.presence.v1.presence import (
+    MousePosition,
+    Presence,
+    Subscriber,
+)
+# isort: on
 from reboot.std.presence.v1.presence import (
     ListResponse,
-    MousePosition,
     PositionResponse,
-    Presence,
     StatusResponse,
-    Subscriber,
     presence_library,
 )
 from typing import Optional

--- a/tests/reboot/std/presence/presence_tests.ts
+++ b/tests/reboot/std/presence/presence_tests.ts
@@ -9,7 +9,9 @@ import {
 import { errors_pb } from "@reboot-dev/reboot-api";
 import { MousePosition } from "@reboot-dev/reboot-std/presence/mouse_tracker/v1";
 import { Subscriber } from "@reboot-dev/reboot-std/presence/subscriber/v1";
-import { Presence, presenceLibrary } from "@reboot-dev/reboot-std/presence/v1";
+import { Presence } from "@reboot-dev/reboot-std/presence/v1";
+// eslint-disable-next-line
+import { presenceLibrary } from "@reboot-dev/reboot-std/presence/v1";
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
 

--- a/tests/reboot/std/presence/presence_tests.ts
+++ b/tests/reboot/std/presence/presence_tests.ts
@@ -6,6 +6,7 @@ import {
   TokenVerifier,
   allow,
 } from "@reboot-dev/reboot";
+import { fork } from "child_process";
 import { errors_pb } from "@reboot-dev/reboot-api";
 import { MousePosition } from "@reboot-dev/reboot-std/presence/mouse_tracker/v1";
 import { Subscriber } from "@reboot-dev/reboot-std/presence/subscriber/v1";
@@ -14,6 +15,7 @@ import { Presence } from "@reboot-dev/reboot-std/presence/v1";
 import { presenceLibrary } from "@reboot-dev/reboot-std/presence/v1";
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
+import * as uuid from "uuid";
 
 class EmptyTokenVerifier extends TokenVerifier {
   async verifyToken(
@@ -171,4 +173,81 @@ test("Use Presence Servicers", async (t) => {
       });
     }
   );
+
+  await t.test("Subscriber connection", async (t) => {
+    await rbt.up(
+      new Application({
+        libraries: [presenceLibrary()],
+        tokenVerifier: new EmptyTokenVerifier(),
+      }),
+      {
+        // needed so URL starts with http:
+        localEnvoy: true,
+      }
+    );
+
+    let context = rbt.createExternalContext("test-connect");
+    let subscriberRef = Subscriber.ref("connect-test-subscriber");
+
+    await subscriberRef.idempotently().create(context);
+    let nonce = uuid.v4();
+
+    // Connect the subscriber. The following would work if we could cancel
+    // the promise/RPC so the test could end. However, because we can't, we use
+    // a subprocess instead. Left here to grab for documentation.
+
+    // let connectFailed = false;
+    // const promise = subscriberRef
+    //   .connect(context, { nonce })
+    //   .catch((_) => {
+    //     connectFailed = true;
+    //   });
+
+    const subprocess = fork(
+      "./tests/reboot/std/presence/subscriber_connect.js",
+      [rbt.url(), subscriberRef.stateId, nonce]
+    );
+
+    let attempt = 0;
+    while (true) {
+      try {
+        await subscriberRef
+          .idempotently(`attempt-${attempt}`)
+          .toggle(context, { nonce });
+      } catch (e) {
+        if (
+          e instanceof Subscriber.ToggleAborted &&
+          e.error instanceof errors_pb.NotFound
+        ) {
+          attempt++;
+          continue;
+        } else {
+          break;
+        }
+      }
+
+      await Presence.ref("connect-test").subscribe(context, {
+        subscriberId: subscriberRef.stateId,
+      });
+      break;
+    }
+
+    let { present } = await subscriberRef.status(context);
+    assert(present);
+
+    // Tell the child process it can exit.
+    subprocess.send("");
+
+    await new Promise<void>((resolve, reject) => {
+      subprocess.on("exit", (code, signal) => {
+        if (code === 0) {
+          resolve();
+        } else if (signal === null) {
+          reject(new Error(`Child exited with code ${code}`));
+        } else {
+          reject(new Error(`Child exited with signal ${signal}`));
+        }
+      });
+    });
+  });
 });

--- a/tests/reboot/std/presence/subscriber_connect.ts
+++ b/tests/reboot/std/presence/subscriber_connect.ts
@@ -1,0 +1,22 @@
+import { ExternalContext } from "@reboot-dev/reboot";
+import { Subscriber } from "@reboot-dev/reboot-std/presence/subscriber/v1";
+
+const args = process.argv.slice(2);
+const url = args[0];
+const subscriberId = args[1];
+const nonce = args[2];
+
+const context = new ExternalContext({ name: "subscriber-connect", url });
+const subscriber = Subscriber.ref(subscriberId);
+
+subscriber.connect(context, { nonce });
+
+await new Promise<void>((resolve) => {
+  process.once("message", () => {
+    resolve();
+  });
+});
+
+// Need to explicitly exit because the call to `testLongRunningWriter`
+// should still be outstanding.
+process.exit(0);


### PR DESCRIPTION
1. Docs for Presence
    * Pushed to the "top" the react library for presence, however standard service usage is below.
2. Edits the React presence library so it doesn't rely on tailwind
3. Added test on the TS side for connecting a subscriber (largely to confirm docs code). Unfortunately, it's not directly liftable into the docs, but did my best to leave bread crumbs as to what's happening.