### PR TITLE
Fix two transaction hangs, and other CI flakes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -351,10 +351,19 @@ jobs:
         QUERY='tests(//tests/...)'
 
         # 2) Exclude these tags by default for MacOS.
+        #
+        # A test carries `platform-independent` when it exercises no
+        # behavior that could differ between Linux and MacOS, or when
+        # whatever platform-dependent behavior it does exercise is also
+        # exercised by a `medium`-or-smaller test that still runs here.
+        # Such a test spends time on our slowest and most expensive
+        # runners for signal that the Linux jobs — which keep running
+        # every test — already give us.
         QUERY="$QUERY \
         except attr(\"tags\",\"requires-docker\",//tests/...) \
         except attr(\"tags\",\"macos_not_supported\",//tests/...) \
         except attr(\"tags\",\"requires-linux-x86\",//tests/...) \
+        except attr(\"tags\",\"platform-independent\",//tests/...) \
         except attr(\"tags\",\"manual\",//tests/...)"
 
         # 3) If this is a PR labelled "reboot-release", also drop flaky

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -352,18 +352,18 @@ jobs:
 
         # 2) Exclude these tags by default for MacOS.
         #
-        # A test carries `platform-independent` when it exercises no
-        # behavior that could differ between Linux and MacOS, or when
-        # whatever platform-dependent behavior it does exercise is also
-        # exercised by a `medium`-or-smaller test that still runs here.
-        # Such a test spends time on our slowest and most expensive
-        # runners for signal that the Linux jobs — which keep running
-        # every test — already give us.
+        # `macos-nightly-only` marks the tests whose MacOS results we
+        # are content to have once a day instead of on every pull
+        # request. They are among our slowest, and MacOS is our
+        # slowest and most expensive runner, so here — on the critical
+        # path of every merge — they cost more than they are worth.
+        # They keep running on Linux in this same run, and on MacOS in
+        # `.github/workflows/macos_nightly.yml`.
         QUERY="$QUERY \
         except attr(\"tags\",\"requires-docker\",//tests/...) \
         except attr(\"tags\",\"macos_not_supported\",//tests/...) \
         except attr(\"tags\",\"requires-linux-x86\",//tests/...) \
-        except attr(\"tags\",\"platform-independent\",//tests/...) \
+        except attr(\"tags\",\"macos-nightly-only\",//tests/...) \
         except attr(\"tags\",\"manual\",//tests/...)"
 
         # 3) If this is a PR labelled "reboot-release", also drop flaky

--- a/.github/workflows/macos_nightly.yml
+++ b/.github/workflows/macos_nightly.yml
@@ -1,0 +1,182 @@
+name: Nightly MacOS Tests
+
+# The tests tagged `macos-nightly-only`, once a day, against `main`.
+# Their MacOS results come from here rather than from every pull
+# request, where our slowest and most expensive runners sit on the
+# critical path of a merge.
+on:
+  schedule:
+    # An hour when pull request traffic is low, so that the nightly is
+    # not competing with pull requests for the MacOS runners it needs.
+    - cron: "0 7 * * *"
+  # Manual trigger, so a maintainer can have the full MacOS set run
+  # now rather than tomorrow.
+  workflow_dispatch:
+
+concurrency:
+  # One nightly at a time. A run still going when the next one comes
+  # around is the interesting one, so it gets to finish.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  new-code:
+    name: Check for new code
+    runs-on: depot-ubuntu-24.04
+    outputs:
+      found: ${{ steps.commits.outputs.found }}
+    steps:
+      - name: Look for commits since the last nightly
+        id: commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -eu
+          if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "Started by hand, so running whatever main has done."
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          LATEST=$(gh api "repos/$GITHUB_REPOSITORY/commits/main" \
+            --jq .commit.committer.date)
+          # 25 hours rather than 24, so that a nightly starting a
+          # little late cannot step over a commit that landed a little
+          # early. Both timestamps are UTC ISO 8601, which sorts
+          # lexicographically.
+          CUTOFF=$(date -u -d '25 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          echo "Latest commit on main: $LATEST (cutoff $CUTOFF)"
+          if [ "$LATEST" \< "$CUTOFF" ]; then
+            echo "Nothing new to test."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    name: Test on MacOS
+    needs: new-code
+    if: ${{ needs.new-code.outputs.found == 'true' }}
+    uses: ./.github/workflows/reboot_macos_environment.yml
+    secrets: inherit
+    with:
+      runs-on: depot-macos-15
+      run: |
+        # Fail if any part of this workflow fails.
+        set -eux
+
+        # 1) Build up the base query: the tests whose MacOS results
+        # this workflow is responsible for.
+        QUERY='attr("tags","macos-nightly-only",tests(//tests/...))'
+
+        # 2) Exclude the tags that cannot run on MacOS at all.
+        QUERY="$QUERY \
+        except attr(\"tags\",\"requires-docker\",//tests/...) \
+        except attr(\"tags\",\"macos_not_supported\",//tests/...) \
+        except attr(\"tags\",\"requires-linux-x86\",//tests/...) \
+        except attr(\"tags\",\"manual\",//tests/...)"
+
+        # 3) Build test targets first so that test execution doesn't
+        # compete with compilation for I/O.
+        echo "▶ bazel query: $QUERY"
+        TARGETS=$(bazel query "$QUERY")
+        echo "$TARGETS" | xargs bazel build
+
+        # 4) Run tests; all build artifacts are cached so this only
+        # executes tests. Keep the output, and keep going on failure,
+        # so that step 5 can say which targets failed.
+        set +e
+        echo "$TARGETS" | xargs bazel test 2>&1 | tee bazel-test.log
+        returncode=${PIPESTATUS[1]}
+        set -e
+
+        # 5) Bazel ends with one line per target that did not pass,
+        # e.g. `//tests/reboot/examples/bank:test  FAILED in 12.3s`.
+        # Hand those to the job that mails the report, then finish
+        # with the status the tests actually had.
+        FAILED=$(grep -oE '^//[^ ]+ +(FAILED|TIMEOUT)' bazel-test.log \
+          | awk '{print $1}' | sort -u)
+        {
+          echo "failed-targets<<END_OF_TARGETS"
+          echo "$FAILED"
+          echo "END_OF_TARGETS"
+        } >> "$GITHUB_OUTPUT"
+        exit "$returncode"
+
+  report:
+    name: Report the result
+    needs: [new-code, test]
+    if: ${{ always() && needs.new-code.outputs.found == 'true' }}
+    runs-on: depot-ubuntu-24.04
+    # Puts `MAILGUN_API_KEY` out of reach of everything but this job:
+    # the secret lives on this environment, and the environment accepts
+    # `main` only. `build_and_test.yml` runs fork pull requests' own
+    # code with `secrets: inherit`, so repository-wide is too wide for
+    # a credential that can send mail as `reboot.dev`.
+    environment: nightly
+    env:
+      # The Mailgun domain the report is sent from, which is ordinary
+      # public information; the credential that goes with it is the
+      # `MAILGUN_API_KEY` secret.
+      MAILGUN_DOMAIN: reboot.dev
+    steps:
+      - name: Compose the report
+        id: compose
+        env:
+          RESULT: ${{ needs.test.result }}
+          FAILED_TARGETS: ${{ needs.test.outputs.failed-targets }}
+        run: |
+          set -eu
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+          RUN_URL="$RUN_URL/actions/runs/$GITHUB_RUN_ID"
+          {
+            echo "subject=Nightly MacOS tests: $RESULT"
+            echo "body<<END_OF_BODY"
+            echo "Result: $RESULT"
+            echo "Repository: $GITHUB_REPOSITORY"
+            echo "Branch: main"
+            echo "Run: $RUN_URL"
+            if [ -n "${FAILED_TARGETS//[[:space:]]/}" ]; then
+              echo ""
+              echo "Targets that did not pass:"
+              echo "$FAILED_TARGETS" | sed '/^[[:space:]]*$/d; s/^/  /'
+            elif [ "$RESULT" != "success" ]; then
+              echo ""
+              echo "No target list: the run did not get as far as"
+              echo "reporting one. The log above is where to look."
+            fi
+            echo "END_OF_BODY"
+          } >> "$GITHUB_OUTPUT"
+          echo "$RUN_URL is $RESULT"
+
+      - name: Email the report
+        env:
+          MAILGUN_API_KEY: ${{ secrets.MAILGUN_API_KEY }}
+          REPORT_TO: ${{ vars.NIGHTLY_REPORT_TO }}
+          SUBJECT: ${{ steps.compose.outputs.subject }}
+          BODY: ${{ steps.compose.outputs.body }}
+        run: |
+          set -eu
+          if [ -z "$MAILGUN_API_KEY" ] || [ -z "$REPORT_TO" ]; then
+            echo "Mail wants the MAILGUN_API_KEY secret and the"
+            echo "NIGHTLY_REPORT_TO variable; with either one missing"
+            echo "the step above is the whole of the report."
+            exit 0
+          fi
+          # The credential goes to `curl` on stdin rather than in an
+          # argument, which keeps it out of the process list.
+          printf 'user = "api:%s"\n' "$MAILGUN_API_KEY" \
+            | curl -sS --config - --fail-with-body --max-time 30 \
+              "https://api.mailgun.net/v3/$MAILGUN_DOMAIN/messages" \
+              -F from="Reboot CI <ci@$MAILGUN_DOMAIN>" \
+              -F to="$REPORT_TO" \
+              -F subject="$SUBJECT" \
+              -F text="$BODY"
+
+      # A red nightly should show in the Actions tab as well as in
+      # whatever inbox the mail landed in.
+      - name: Fail if the tests failed
+        if: ${{ needs.test.result != 'success' }}
+        run: |
+          echo "Nightly MacOS tests concluded: ${{ needs.test.result }}"
+          exit 1

--- a/.github/workflows/reboot_macos_environment.yml
+++ b/.github/workflows/reboot_macos_environment.yml
@@ -25,6 +25,13 @@ on:
         required: false
         type: string
         default: "UTC"
+    outputs:
+      failed-targets:
+        description: >-
+          Whatever the `run` script wrote to `failed-targets` in
+          `$GITHUB_OUTPUT`, by convention one Bazel target per line.
+          Empty unless the script writes it.
+        value: ${{ jobs.run.outputs.failed-targets }}
   workflow_dispatch:
     inputs:
       runs-on:
@@ -78,6 +85,8 @@ jobs:
     name: Build Reboot for MacOS
     needs: [check-runner, check-secrets]
     runs-on: ${{ inputs.runs-on }}
+    outputs:
+      failed-targets: ${{ steps.commands.outputs.failed-targets }}
     env:
       # Disable the automatic update of Homebrew and the after install
       # cleanup to save a bunch of time.
@@ -248,6 +257,7 @@ jobs:
           echo $GCP_REMOTE_CACHE_CREDENTIALS_BASE64 | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
 
       - name: Run commands
+        id: commands
         run: |
           # 'pip' installs 'mypy' at /opt/homebrew/bin/mypy, but we need to
           # access it from 'sh_test', so we need to provide binaries for the

--- a/reboot/aio/state_managers.py
+++ b/reboot/aio/state_managers.py
@@ -1547,11 +1547,11 @@ class Lock:
       transaction. Passing `deadline=None` means wait forever or until
       the task is cancelled.
 
-    - A waiter that has given up, i.e., whose `deadline` elapsed or
-      whose task was cancelled, is dropped rather than granted (see
-      `_Waiter.abandoned()`). Granting to one would leave the lock
-      held by nobody, and every later acquire on the state it guards
-      would then fail or block forever.
+    - A waiter whose `deadline` elapsed or whose task was cancelled
+      may still be granted the hold it queued for, because a release
+      can reach it before it is resumed to take itself off the queue.
+      It hands that hold straight back as it unwinds, so whoever
+      queued behind it is granted a turn of the event loop later.
 
     The lock is not `asyncio.Task` aware because it is meant to be
     used across multiple different calls on the same state, i.e.,
@@ -1564,6 +1564,11 @@ class Lock:
         EXCLUSIVE = "exclusive"
 
     class _Waiter:
+        """A queued request for a hold, and the future that a grant of
+        that hold resolves. Only `_maybe_grant_next()` ever resolves
+        it, and it does so at the moment it takes the waiter off the
+        queue, so a resolved future means this waiter holds the lock,
+        even if whoever queued it has since given up."""
 
         __slots__ = ("mode", "future")
 
@@ -1572,21 +1577,6 @@ class Lock:
             self.future: asyncio.Future[None] = (
                 asyncio.get_event_loop().create_future()
             )
-
-        def abandoned(self) -> bool:
-            """`True` once this waiter can no longer take the hold it
-            is queued for, because its acquire deadline elapsed or its
-            task was cancelled. It is still on the queue only because
-            it has not been resumed yet to remove itself. Granting to
-            it would mark the lock held with nobody left to release
-            it, leaving the state this lock guards unusable for the
-            life of the process, so such a waiter must be dropped.
-
-            A waiter that is granted is removed from the queue at the
-            same time its future is resolved, and nothing else
-            resolves a queued waiter's future, so a waiter that is
-            still queued and whose future is resolved has given up."""
-            return self.future.done()
 
     def __init__(self) -> None:
         # Number of shared holders.
@@ -1728,17 +1718,6 @@ class Lock:
         except ValueError:
             pass
 
-    def _remove_upgrader(self, waiter: Lock._Waiter) -> None:
-        """Empties the upgrade slot, but only while `waiter` is the
-        waiter occupying it. A waiter that has given up may already
-        have been dropped from the slot, and by the time it cleans up
-        after itself another holder may have registered an upgrade of
-        its own there. That one must be left in place: emptying the
-        slot would leave it registered nowhere, and a waiter nothing
-        holds a reference to is a waiter nothing can ever grant."""
-        if self._upgrader is waiter:
-            self._upgrader = None
-
     @overload
     async def _wait(
         self,
@@ -1794,27 +1773,21 @@ class Lock:
 
         timeout = deadline.total_seconds() if deadline is not None else None
         try:
-            await asyncio.wait_for(waiter.future, timeout=timeout)
-        except asyncio.TimeoutError:
-            if upgrade:
-                self._remove_upgrader(waiter)
-            else:
-                self._remove_waiter(waiter)
-            raise SystemAborted(
-                Unavailable(),
-                message=(
-                    f"Timed out waiting {timeout:.1f}s to "
-                    f"{'upgrade to' if upgrade else 'acquire'} "
-                    f"{mode.value} lock; retry the transaction."
-                ),
+            # Shielded so that our deadline elapsing, or our task being
+            # cancelled, cancels only our wait on the future and not the
+            # future itself. A grant then stays the only thing that can
+            # resolve it, which is what lets us tell below whether the
+            # hold became ours while we were on our way out.
+            await asyncio.wait_for(
+                asyncio.shield(waiter.future), timeout=timeout
             )
-        except BaseException:
-            # Cancellation or other exception, but we may have already
-            # been granted and thus must release before re-raising.
-            if (
-                waiter.future.done() and not waiter.future.cancelled() and
-                waiter.future.exception() is None
-            ):
+        except BaseException as exception:
+            if waiter.future.done():
+                # A release reached us before we could take ourselves
+                # off the queue, so the hold is ours, and ours to give
+                # back: nothing else will, and a hold nobody releases
+                # leaves the state this lock guards unusable for the
+                # life of the process.
                 if upgrade:
                     # An upgrade whose caller is interrupted leaves
                     # that caller holding the shared hold it upgrades
@@ -1826,9 +1799,23 @@ class Lock:
                 else:
                     self.release_exclusive()
             elif upgrade:
-                self._remove_upgrader(waiter)
+                # Only a grant takes a waiter out of the upgrade slot,
+                # and a granted waiter took the branch above, so the
+                # slot is still ours to empty.
+                assert self._upgrader is waiter
+                self._upgrader = None
             else:
                 self._remove_waiter(waiter)
+
+            if isinstance(exception, asyncio.TimeoutError):
+                raise SystemAborted(
+                    Unavailable(),
+                    message=(
+                        f"Timed out waiting {timeout:.1f}s to "
+                        f"{'upgrade to' if upgrade else 'acquire'} "
+                        f"{mode.value} lock; retry the transaction."
+                    ),
+                )
             raise
 
     def _maybe_grant_next(self, *, released: Lock.Mode) -> None:
@@ -1849,21 +1836,14 @@ class Lock:
             # other remaining shared holders, bypassing any queued
             # exclusive waiters.
             assert released == Lock.Mode.SHARED
-            if self._upgrader.abandoned():
-                # The upgrader has given up, so forget it and grant as
-                # if it had never asked. It keeps the shared hold it
-                # upgrades from and releases that itself.
-                self._upgrader = None
-            elif self._shared == 1:
+            if self._shared == 1:
                 upgrader = self._upgrader
                 self._upgrader = None
                 self._shared = 0
                 self._exclusive = True
                 upgrader.future.set_result(None)
-                return
-            else:
-                # While we have an upgrader nothing else gets granted.
-                return
+            # While we have an upgrader nothing else gets granted.
+            return
 
         # Nothing to do if we released a shared hold but still have
         # shared holders.
@@ -1877,11 +1857,6 @@ class Lock:
         # Grant waiters in FIFO ordering.
         while self._waiters:
             waiter = self._waiters[0]
-            if waiter.abandoned():
-                # Drop the waiter and try the next one rather than
-                # taking the lock on its behalf (see `abandoned()`).
-                self._waiters.pop(0)
-                continue
             if waiter.mode == Lock.Mode.EXCLUSIVE:
                 # We may have granted a shared waiter below if the
                 # _first_ waiter was not exclusive and thus we've now
@@ -5415,11 +5390,14 @@ class SidecarStateManager(
         # future to `None`, so a participant `Watch` that already passed
         # the "is it still in the map" check and is awaiting the future
         # observes the abort rather than finding itself still listed to
-        # commit. Both statements are synchronous and come before
-        # anything that can be interrupted, so from here on every
-        # watcher has an answer no matter where a cancellation lands.
+        # commit.
         #
-        # Answering before the database cleanup below lands is safe,
+        # IMPORTANT: we need to resolve the future even if we fail to
+        # call the database or fail to call the participants, or get
+        # cancelled while doing either of those things! Thus we resolve
+        # the future _before_ doing anything else.
+        #
+        # Resolving the future _before_ the database cleanup is safe,
         # because an abort is not something a coordinator records: its
         # durable outcomes are "preparing" and "absent", and neither
         # says a transaction committed. A coordinator only gets here

--- a/reboot/aio/state_managers.py
+++ b/reboot/aio/state_managers.py
@@ -5404,13 +5404,43 @@ class SidecarStateManager(
         participants: Participants,
         coordinator_state_ref: Optional[StateRef],
     ):
-        """Aborts a transaction for which we are the coordinator: (1) cleans
-        up the "preparing" record that may be in the database; (2)
-        best-effort sends `Abort` RPCs to all participants; and (3)
-        resolves the `_coordinator_participants` future to `None` so
-        any participant "watch control loops" observe the abort, then
-        deletes the future entry.
+        """Aborts a transaction for which we are the coordinator: (1)
+        resolves the `_coordinator_participants` future to `None` and
+        drops its entry so any participant "watch control loops"
+        observe the abort; (2) cleans up the "preparing" record that
+        may be in the database; and (3) best-effort sends `Abort` RPCs
+        to all participants.
         """
+        # To indicate that the transaction has aborted we resolve the
+        # future to `None`, so a participant `Watch` that already passed
+        # the "is it still in the map" check and is awaiting the future
+        # observes the abort rather than finding itself still listed to
+        # commit. Both statements are synchronous and come before
+        # anything that can be interrupted, so from here on every
+        # watcher has an answer no matter where a cancellation lands.
+        #
+        # Answering before the database cleanup below lands is safe,
+        # because an abort is not something a coordinator records: its
+        # durable outcomes are "preparing" and "absent", and neither
+        # says a transaction committed. A coordinator only gets here
+        # while the transaction is not durably prepared -- either its
+        # `_transaction_coordinator_complete()` did not return, or it
+        # is re-preparing, which asserts as much -- so there is no
+        # committed outcome for an early answer to contradict. Should
+        # this process die before the cleanup lands, recovery finds
+        # "preparing" and re-prepares, the participants that have
+        # already aborted report that they never prepared, and the
+        # transaction aborts again.
+        #
+        # Not expecting the future to ever be cancelled, see:
+        # https://github.com/reboot-dev/mono/issues/3241
+        assert not self._coordinator_participants[transaction_id].cancelled()
+        self._coordinator_participants[transaction_id].set_result(None)
+
+        # Remove transaction so that participants "watch control loop"
+        # will determine that the transaction has aborted!
+        del self._coordinator_participants[transaction_id]
+
         # Clean up the "preparing" record that may be in the database
         # when the coordinator stored the transaction participants
         # (and `preparing=True`). The database write may or may not
@@ -5474,21 +5504,6 @@ class SidecarStateManager(
             abort(state_type, state_ref)
             for (state_type, state_ref) in participants.should_prepare()
         )
-
-        # To indicate that the transaction has aborted we resolve the
-        # future to `None`, so a participant `Watch` that already passed
-        # the "is it still in the map" check and is awaiting the future
-        # observes the abort rather than finding itself still listed to
-        # commit.
-        #
-        # Not expecting the future to ever be cancelled, see:
-        # https://github.com/reboot-dev/mono/issues/3241
-        assert not self._coordinator_participants[transaction_id].cancelled()
-        self._coordinator_participants[transaction_id].set_result(None)
-
-        # Remove transaction so that participants "watch control loop"
-        # will determine that the transaction has aborted!
-        del self._coordinator_participants[transaction_id]
 
     async def _transaction_participant_watch(
         self,

--- a/reboot/aio/state_managers.py
+++ b/reboot/aio/state_managers.py
@@ -1547,6 +1547,12 @@ class Lock:
       transaction. Passing `deadline=None` means wait forever or until
       the task is cancelled.
 
+    - A waiter that has given up, i.e., whose `deadline` elapsed or
+      whose task was cancelled, is dropped rather than granted (see
+      `_Waiter.abandoned()`). Granting to one would leave the lock
+      held by nobody, and every later acquire on the state it guards
+      would then fail or block forever.
+
     The lock is not `asyncio.Task` aware because it is meant to be
     used across multiple different calls on the same state, i.e.,
     across transactions. Instead, it tracks shared as a count and
@@ -1566,6 +1572,21 @@ class Lock:
             self.future: asyncio.Future[None] = (
                 asyncio.get_event_loop().create_future()
             )
+
+        def abandoned(self) -> bool:
+            """`True` once this waiter can no longer take the hold it
+            is queued for, because its acquire deadline elapsed or its
+            task was cancelled. It is still on the queue only because
+            it has not been resumed yet to remove itself. Granting to
+            it would mark the lock held with nobody left to release
+            it, leaving the state this lock guards unusable for the
+            life of the process, so such a waiter must be dropped.
+
+            A waiter that is granted is removed from the queue at the
+            same time its future is resolved, and nothing else
+            resolves a queued waiter's future, so a waiter that is
+            still queued and whose future is resolved has given up."""
+            return self.future.done()
 
     def __init__(self) -> None:
         # Number of shared holders.
@@ -1707,6 +1728,17 @@ class Lock:
         except ValueError:
             pass
 
+    def _remove_upgrader(self, waiter: Lock._Waiter) -> None:
+        """Empties the upgrade slot, but only while `waiter` is the
+        waiter occupying it. A waiter that has given up may already
+        have been dropped from the slot, and by the time it cleans up
+        after itself another holder may have registered an upgrade of
+        its own there. That one must be left in place: emptying the
+        slot would leave it registered nowhere, and a waiter nothing
+        holds a reference to is a waiter nothing can ever grant."""
+        if self._upgrader is waiter:
+            self._upgrader = None
+
     @overload
     async def _wait(
         self,
@@ -1765,7 +1797,7 @@ class Lock:
             await asyncio.wait_for(waiter.future, timeout=timeout)
         except asyncio.TimeoutError:
             if upgrade:
-                self._upgrader = None
+                self._remove_upgrader(waiter)
             else:
                 self._remove_waiter(waiter)
             raise SystemAborted(
@@ -1783,12 +1815,18 @@ class Lock:
                 waiter.future.done() and not waiter.future.cancelled() and
                 waiter.future.exception() is None
             ):
-                if mode == Lock.Mode.SHARED:
+                if upgrade:
+                    # An upgrade whose caller is interrupted leaves
+                    # that caller holding the shared hold it upgrades
+                    # from, so hand that back rather than releasing
+                    # the exclusive hold outright.
+                    self.downgrade()
+                elif mode == Lock.Mode.SHARED:
                     self.release_shared()
                 else:
                     self.release_exclusive()
             elif upgrade:
-                self._upgrader = None
+                self._remove_upgrader(waiter)
             else:
                 self._remove_waiter(waiter)
             raise
@@ -1811,15 +1849,21 @@ class Lock:
             # other remaining shared holders, bypassing any queued
             # exclusive waiters.
             assert released == Lock.Mode.SHARED
-            if self._shared == 1:
+            if self._upgrader.abandoned():
+                # The upgrader has given up, so forget it and grant as
+                # if it had never asked. It keeps the shared hold it
+                # upgrades from and releases that itself.
+                self._upgrader = None
+            elif self._shared == 1:
                 upgrader = self._upgrader
                 self._upgrader = None
                 self._shared = 0
                 self._exclusive = True
-                if not upgrader.future.done():
-                    upgrader.future.set_result(None)
-            # While we have an upgrader nothing else gets granted.
-            return
+                upgrader.future.set_result(None)
+                return
+            else:
+                # While we have an upgrader nothing else gets granted.
+                return
 
         # Nothing to do if we released a shared hold but still have
         # shared holders.
@@ -1833,6 +1877,11 @@ class Lock:
         # Grant waiters in FIFO ordering.
         while self._waiters:
             waiter = self._waiters[0]
+            if waiter.abandoned():
+                # Drop the waiter and try the next one rather than
+                # taking the lock on its behalf (see `abandoned()`).
+                self._waiters.pop(0)
+                continue
             if waiter.mode == Lock.Mode.EXCLUSIVE:
                 # We may have granted a shared waiter below if the
                 # _first_ waiter was not exclusive and thus we've now
@@ -1841,14 +1890,12 @@ class Lock:
                     return
                 self._waiters.pop(0)
                 self._exclusive = True
-                if not waiter.future.done():
-                    waiter.future.set_result(None)
+                waiter.future.set_result(None)
                 return
             # The mode is `Lock.Mode.SHARED`.
             self._waiters.pop(0)
             self._shared += 1
-            if not waiter.future.done():
-                waiter.future.set_result(None)
+            waiter.future.set_result(None)
             # Continue granting a cohort of shared waiters up until
             # the first exclusive waiter.
 

--- a/reboot/aio/state_managers.py
+++ b/reboot/aio/state_managers.py
@@ -5394,13 +5394,43 @@ class SidecarStateManager(
         participants: Participants,
         coordinator_state_ref: Optional[StateRef],
     ):
-        """Aborts a transaction for which we are the coordinator: (1) cleans
-        up the "preparing" record that may be in the database; (2)
-        best-effort sends `Abort` RPCs to all participants; and (3)
-        resolves the `_coordinator_participants` future to `None` so
-        any participant "watch control loops" observe the abort, then
-        deletes the future entry.
+        """Aborts a transaction for which we are the coordinator: (1)
+        resolves the `_coordinator_participants` future to `None` and
+        drops its entry so any participant "watch control loops"
+        observe the abort; (2) cleans up the "preparing" record that
+        may be in the database; and (3) best-effort sends `Abort` RPCs
+        to all participants.
         """
+        # To indicate that the transaction has aborted we resolve the
+        # future to `None`, so a participant `Watch` that already passed
+        # the "is it still in the map" check and is awaiting the future
+        # observes the abort rather than finding itself still listed to
+        # commit. Both statements are synchronous and come before
+        # anything that can be interrupted, so from here on every
+        # watcher has an answer no matter where a cancellation lands.
+        #
+        # Answering before the database cleanup below lands is safe,
+        # because an abort is not something a coordinator records: its
+        # durable outcomes are "preparing" and "absent", and neither
+        # says a transaction committed. A coordinator only gets here
+        # while the transaction is not durably prepared -- either its
+        # `_transaction_coordinator_complete()` did not return, or it
+        # is re-preparing, which asserts as much -- so there is no
+        # committed outcome for an early answer to contradict. Should
+        # this process die before the cleanup lands, recovery finds
+        # "preparing" and re-prepares, the participants that have
+        # already aborted report that they never prepared, and the
+        # transaction aborts again.
+        #
+        # Not expecting the future to ever be cancelled, see:
+        # https://github.com/reboot-dev/mono/issues/3241
+        assert not self._coordinator_participants[transaction_id].cancelled()
+        self._coordinator_participants[transaction_id].set_result(None)
+
+        # Remove transaction so that participants "watch control loop"
+        # will determine that the transaction has aborted!
+        del self._coordinator_participants[transaction_id]
+
         # Clean up the "preparing" record that may be in the database
         # when the coordinator stored the transaction participants
         # (and `preparing=True`). The database write may or may not
@@ -5464,21 +5494,6 @@ class SidecarStateManager(
             abort(state_type, state_ref)
             for (state_type, state_ref) in participants.should_prepare()
         )
-
-        # To indicate that the transaction has aborted we resolve the
-        # future to `None`, so a participant `Watch` that already passed
-        # the "is it still in the map" check and is awaiting the future
-        # observes the abort rather than finding itself still listed to
-        # commit.
-        #
-        # Not expecting the future to ever be cancelled, see:
-        # https://github.com/reboot-dev/mono/issues/3241
-        assert not self._coordinator_participants[transaction_id].cancelled()
-        self._coordinator_participants[transaction_id].set_result(None)
-
-        # Remove transaction so that participants "watch control loop"
-        # will determine that the transaction has aborted!
-        del self._coordinator_participants[transaction_id]
 
     async def _transaction_participant_watch(
         self,

--- a/tests/reboot/agents/pydantic_ai/BUILD.bazel
+++ b/tests/reboot/agents/pydantic_ai/BUILD.bazel
@@ -6,6 +6,10 @@ py_test(
     timeout = "long",
     srcs = [":agent_tests.py"],
     main = "agent_tests.py",
+    # This exercises the `pydantic-ai` integration against a mocked
+    # model (`FunctionModel`) on the in-process `Reboot()` test
+    # harness; neither has platform-dependent behavior.
+    tags = ["platform-independent"],
     deps = [
         requirement("mcp"),
         requirement("pydantic-ai-slim"),

--- a/tests/reboot/agents/pydantic_ai/BUILD.bazel
+++ b/tests/reboot/agents/pydantic_ai/BUILD.bazel
@@ -6,10 +6,7 @@ py_test(
     timeout = "long",
     srcs = [":agent_tests.py"],
     main = "agent_tests.py",
-    # This exercises the `pydantic-ai` integration against a mocked
-    # model (`FunctionModel`) on the in-process `Reboot()` test
-    # harness; neither has platform-dependent behavior.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     deps = [
         requirement("mcp"),
         requirement("pydantic-ai-slim"),

--- a/tests/reboot/cli/init/BUILD.bazel
+++ b/tests/reboot/cli/init/BUILD.bazel
@@ -96,7 +96,15 @@ sh_test(
     # Additionally, in all our example tests, we initiate LocalEnvoy on the
     # default secure port 9991. We require 'exclusive' to not run multiple
     # tests, that use the same port, concurrently.
+    #
+    # Installing the locally built Reboot npm packages, `rbt generate`
+    # and `npx rbt dev run` are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room-nodejs:test`, and the `rbt
+    # init` flow by `init_sh_test_python310`; both keep running
+    # there, and what is left is the content of the Node.js
+    # templates.
     tags = [
         "exclusive",
+        "platform-independent",
     ],
 )

--- a/tests/reboot/cli/init/BUILD.bazel
+++ b/tests/reboot/cli/init/BUILD.bazel
@@ -96,15 +96,8 @@ sh_test(
     # Additionally, in all our example tests, we initiate LocalEnvoy on the
     # default secure port 9991. We require 'exclusive' to not run multiple
     # tests, that use the same port, concurrently.
-    #
-    # Installing the locally built Reboot npm packages, `rbt generate`
-    # and `npx rbt dev run` are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room-nodejs:test`, and the `rbt
-    # init` flow by `init_sh_test_python310`; both keep running
-    # there, and what is left is the content of the Node.js
-    # templates.
     tags = [
         "exclusive",
-        "platform-independent",
+        "macos-nightly-only",
     ],
 )

--- a/tests/reboot/examples/agent-wiki/BUILD.bazel
+++ b/tests/reboot/examples/agent-wiki/BUILD.bazel
@@ -30,10 +30,11 @@ osx_env.update({
 
 sh_test_in_working_directory(
     name = "test",
-    # MacOS runners need the full Bazel "large" budget because
-    # `uv sync` cold-fetches the locked dependency tree (and
-    # possibly a managed Python interpreter) into the test
-    # sandbox, which exceeds the default "medium" 300s timeout.
+    # This example depends on the `pydantic-ai` stack on top of
+    # `reboot`, so a cold `uv sync` fetches a much bigger dependency
+    # tree (and possibly a managed Python interpreter) into the test
+    # sandbox than our other example tests do, which on a slow runner
+    # exceeds the default "medium" 300s timeout.
     size = "large",
     data = test_packages + [
         ":test_packages",
@@ -51,7 +52,16 @@ sh_test_in_working_directory(
     # In all our example tests, we initiate LocalEnvoy on the
     # default secure port 9991. We require 'exclusive' to not run
     # multiple tests, that use the same port, concurrently.
-    tags = ["exclusive"],
+    #
+    # The `uv sync`, `rbt generate`, `pytest` and `rbt dev run
+    # --terminate-after-health-check` steps are the same ones that
+    # `//tests/reboot/examples/chat-room:test` runs, and that test
+    # keeps running on MacOS; only the application code in between
+    # differs, so this adds no MacOS-specific coverage.
+    tags = [
+        "exclusive",
+        "platform-independent",
+    ],
     working_directory = "reboot/examples/agent-wiki/",
 )
 
@@ -79,5 +89,12 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/agent-wiki/",
 )

--- a/tests/reboot/examples/agent-wiki/BUILD.bazel
+++ b/tests/reboot/examples/agent-wiki/BUILD.bazel
@@ -30,12 +30,6 @@ osx_env.update({
 
 sh_test_in_working_directory(
     name = "test",
-    # This example depends on the `pydantic-ai` stack on top of
-    # `reboot`, so a cold `uv sync` fetches a much bigger dependency
-    # tree (and possibly a managed Python interpreter) into the test
-    # sandbox than our other example tests do, which on a slow runner
-    # exceeds the default "medium" 300s timeout.
-    size = "large",
     data = test_packages + [
         ":test_packages",
         # The actual test script will be given access to all of

--- a/tests/reboot/examples/agent-wiki/BUILD.bazel
+++ b/tests/reboot/examples/agent-wiki/BUILD.bazel
@@ -46,15 +46,9 @@ sh_test_in_working_directory(
     # In all our example tests, we initiate LocalEnvoy on the
     # default secure port 9991. We require 'exclusive' to not run
     # multiple tests, that use the same port, concurrently.
-    #
-    # The `uv sync`, `rbt generate`, `pytest` and `rbt dev run
-    # --terminate-after-health-check` steps are the same ones that
-    # `//tests/reboot/examples/chat-room:test` runs, and that test
-    # keeps running on MacOS; only the application code in between
-    # differs, so this adds no MacOS-specific coverage.
     tags = [
         "exclusive",
-        "platform-independent",
+        "macos-nightly-only",
     ],
     working_directory = "reboot/examples/agent-wiki/",
 )
@@ -83,12 +77,6 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/agent-wiki/",
 )

--- a/tests/reboot/examples/ai-chat-counter-dashboard/BUILD.bazel
+++ b/tests/reboot/examples/ai-chat-counter-dashboard/BUILD.bazel
@@ -37,5 +37,12 @@ sh_test_in_working_directory(
     # is generated from are copied into the test sandbox; the script
     # `cd`s into `frontend/` itself.
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/ai-chat-counter-dashboard/",
 )

--- a/tests/reboot/examples/ai-chat-counter-dashboard/BUILD.bazel
+++ b/tests/reboot/examples/ai-chat-counter-dashboard/BUILD.bazel
@@ -37,12 +37,6 @@ sh_test_in_working_directory(
     # is generated from are copied into the test sandbox; the script
     # `cd`s into `frontend/` itself.
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/ai-chat-counter-dashboard/",
 )

--- a/tests/reboot/examples/ai-chat-counter/BUILD.bazel
+++ b/tests/reboot/examples/ai-chat-counter/BUILD.bazel
@@ -37,5 +37,12 @@ sh_test_in_working_directory(
     # is generated from are copied into the test sandbox; the script
     # `cd`s into `frontend/` itself.
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/ai-chat-counter/",
 )

--- a/tests/reboot/examples/ai-chat-counter/BUILD.bazel
+++ b/tests/reboot/examples/ai-chat-counter/BUILD.bazel
@@ -37,12 +37,6 @@ sh_test_in_working_directory(
     # is generated from are copied into the test sandbox; the script
     # `cd`s into `frontend/` itself.
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/ai-chat-counter/",
 )

--- a/tests/reboot/examples/bank-pydantic/BUILD.bazel
+++ b/tests/reboot/examples/bank-pydantic/BUILD.bazel
@@ -97,15 +97,9 @@ sh_test_in_working_directory(
     # from are copied into the test sandbox; the script `cd`s into
     # `frontend/mobile/` itself.
     script = "frontend/mobile/.tests/react_native_test.sh",
-    # `npx tsc --noEmit` produces the same result on MacOS as on
-    # Linux; generating the mobile client is exercised on MacOS by
-    # `//tests/reboot/cli/generate:mobile_out_specified_tests_py`,
-    # and installing the locally built Reboot npm packages by
-    # `//tests/reboot/examples/chat-room-nodejs:test`; both keep
-    # running there.
     tags = [
         "exclusive",
-        "platform-independent",
+        "macos-nightly-only",
     ],
     working_directory = "reboot/examples/bank-pydantic/",
 )
@@ -144,12 +138,6 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/bank-pydantic/",
 )

--- a/tests/reboot/examples/bank-pydantic/BUILD.bazel
+++ b/tests/reboot/examples/bank-pydantic/BUILD.bazel
@@ -97,7 +97,16 @@ sh_test_in_working_directory(
     # from are copied into the test sandbox; the script `cd`s into
     # `frontend/mobile/` itself.
     script = "frontend/mobile/.tests/react_native_test.sh",
-    tags = ["exclusive"],
+    # `npx tsc --noEmit` produces the same result on MacOS as on
+    # Linux; generating the mobile client is exercised on MacOS by
+    # `//tests/reboot/cli/generate:mobile_out_specified_tests_py`,
+    # and installing the locally built Reboot npm packages by
+    # `//tests/reboot/examples/chat-room-nodejs:test`; both keep
+    # running there.
+    tags = [
+        "exclusive",
+        "platform-independent",
+    ],
     working_directory = "reboot/examples/bank-pydantic/",
 )
 
@@ -135,5 +144,12 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/bank-pydantic/",
 )

--- a/tests/reboot/examples/bank-zod/BUILD.bazel
+++ b/tests/reboot/examples/bank-zod/BUILD.bazel
@@ -70,5 +70,12 @@ sh_test_in_working_directory(
     ],
     env = general_env,
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/bank-zod/",
 )

--- a/tests/reboot/examples/bank-zod/BUILD.bazel
+++ b/tests/reboot/examples/bank-zod/BUILD.bazel
@@ -70,12 +70,6 @@ sh_test_in_working_directory(
     ],
     env = general_env,
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/bank-zod/",
 )

--- a/tests/reboot/examples/bank/BUILD.bazel
+++ b/tests/reboot/examples/bank/BUILD.bazel
@@ -72,5 +72,12 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/bank/",
 )

--- a/tests/reboot/examples/bank/BUILD.bazel
+++ b/tests/reboot/examples/bank/BUILD.bazel
@@ -72,12 +72,6 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/bank/",
 )

--- a/tests/reboot/examples/boutique/BUILD.bazel
+++ b/tests/reboot/examples/boutique/BUILD.bazel
@@ -80,12 +80,6 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/boutique/",
 )

--- a/tests/reboot/examples/boutique/BUILD.bazel
+++ b/tests/reboot/examples/boutique/BUILD.bazel
@@ -80,5 +80,12 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/boutique/",
 )

--- a/tests/reboot/examples/chat-room/BUILD.bazel
+++ b/tests/reboot/examples/chat-room/BUILD.bazel
@@ -166,15 +166,9 @@ sh_test_in_working_directory(
     # from are copied into the test sandbox; the script `cd`s into
     # `frontend/mobile/` itself.
     script = "frontend/mobile/.tests/react_native_test.sh",
-    # `npx tsc --noEmit` produces the same result on MacOS as on
-    # Linux; generating the mobile client is exercised on MacOS by
-    # `//tests/reboot/cli/generate:mobile_out_specified_tests_py`,
-    # and installing the locally built Reboot npm packages by
-    # `//tests/reboot/examples/chat-room-nodejs:test`; both keep
-    # running there.
     tags = [
         "exclusive",
-        "platform-independent",
+        "macos-nightly-only",
     ],
     working_directory = "reboot/examples/chat-room/",
 )
@@ -214,12 +208,6 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/chat-room/",
 )

--- a/tests/reboot/examples/chat-room/BUILD.bazel
+++ b/tests/reboot/examples/chat-room/BUILD.bazel
@@ -166,7 +166,16 @@ sh_test_in_working_directory(
     # from are copied into the test sandbox; the script `cd`s into
     # `frontend/mobile/` itself.
     script = "frontend/mobile/.tests/react_native_test.sh",
-    tags = ["exclusive"],
+    # `npx tsc --noEmit` produces the same result on MacOS as on
+    # Linux; generating the mobile client is exercised on MacOS by
+    # `//tests/reboot/cli/generate:mobile_out_specified_tests_py`,
+    # and installing the locally built Reboot npm packages by
+    # `//tests/reboot/examples/chat-room-nodejs:test`; both keep
+    # running there.
+    tags = [
+        "exclusive",
+        "platform-independent",
+    ],
     working_directory = "reboot/examples/chat-room/",
 )
 
@@ -205,5 +214,12 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/chat-room/",
 )

--- a/tests/reboot/examples/chick-potle/BUILD.bazel
+++ b/tests/reboot/examples/chick-potle/BUILD.bazel
@@ -74,5 +74,12 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/chick-potle/",
 )

--- a/tests/reboot/examples/chick-potle/BUILD.bazel
+++ b/tests/reboot/examples/chick-potle/BUILD.bazel
@@ -74,12 +74,6 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/chick-potle/",
 )

--- a/tests/reboot/examples/kcdc-2025/BUILD.bazel
+++ b/tests/reboot/examples/kcdc-2025/BUILD.bazel
@@ -29,5 +29,12 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/kcdc-2025/",
 )

--- a/tests/reboot/examples/kcdc-2025/BUILD.bazel
+++ b/tests/reboot/examples/kcdc-2025/BUILD.bazel
@@ -29,12 +29,6 @@ sh_test_in_working_directory(
     ],
     env = frontend_env,
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/kcdc-2025/",
 )

--- a/tests/reboot/examples/monorepo/BUILD.bazel
+++ b/tests/reboot/examples/monorepo/BUILD.bazel
@@ -56,6 +56,15 @@ sh_test_in_working_directory(
     # In all our example tests, we initiate LocalEnvoy on the default
     # secure port 9991. We require 'exclusive' to not run multiple
     # tests, that use the same port, concurrently.
-    tags = ["exclusive"],
+    #
+    # `uv sync`, `rbt generate` and the in-process `pytest` harness
+    # are exercised on MacOS by `//tests/reboot/examples/bank:test`,
+    # which keeps running there; what is left here is `rbt generate`
+    # resolving paths from the sub-directories of a multi-application
+    # workspace, which is pure Python.
+    tags = [
+        "exclusive",
+        "platform-independent",
+    ],
     working_directory = "reboot/examples/monorepo/",
 )

--- a/tests/reboot/examples/monorepo/BUILD.bazel
+++ b/tests/reboot/examples/monorepo/BUILD.bazel
@@ -56,15 +56,9 @@ sh_test_in_working_directory(
     # In all our example tests, we initiate LocalEnvoy on the default
     # secure port 9991. We require 'exclusive' to not run multiple
     # tests, that use the same port, concurrently.
-    #
-    # `uv sync`, `rbt generate` and the in-process `pytest` harness
-    # are exercised on MacOS by `//tests/reboot/examples/bank:test`,
-    # which keeps running there; what is left here is `rbt generate`
-    # resolving paths from the sub-directories of a multi-application
-    # workspace, which is pure Python.
     tags = [
         "exclusive",
-        "platform-independent",
+        "macos-nightly-only",
     ],
     working_directory = "reboot/examples/monorepo/",
 )

--- a/tests/reboot/examples/prosemirror-zod/BUILD.bazel
+++ b/tests/reboot/examples/prosemirror-zod/BUILD.bazel
@@ -47,15 +47,9 @@ sh_test_in_working_directory(
     # Additionally, in all our example tests, we initiate LocalEnvoy on the
     # default secure port 9991. We require 'exclusive' to not run multiple
     # tests, that use the same port, concurrently.
-    #
-    # `.tests/test.sh` here is identical to the one that
-    # `//tests/reboot/examples/prosemirror:test` runs on MacOS;
-    # only the schema style (zod instead of `.proto`) and the
-    # generated client that follows from it differ, which is
-    # codegen rather than platform behavior.
     tags = [
         "exclusive",
-        "platform-independent",
+        "macos-nightly-only",
     ],
     working_directory = "reboot/examples/prosemirror-zod",
 )

--- a/tests/reboot/examples/prosemirror-zod/BUILD.bazel
+++ b/tests/reboot/examples/prosemirror-zod/BUILD.bazel
@@ -47,8 +47,15 @@ sh_test_in_working_directory(
     # Additionally, in all our example tests, we initiate LocalEnvoy on the
     # default secure port 9991. We require 'exclusive' to not run multiple
     # tests, that use the same port, concurrently.
+    #
+    # `.tests/test.sh` here is identical to the one that
+    # `//tests/reboot/examples/prosemirror:test` runs on MacOS;
+    # only the schema style (zod instead of `.proto`) and the
+    # generated client that follows from it differ, which is
+    # codegen rather than platform behavior.
     tags = [
         "exclusive",
+        "platform-independent",
     ],
     working_directory = "reboot/examples/prosemirror-zod",
 )

--- a/tests/reboot/examples/reboot-swag-store/BUILD.bazel
+++ b/tests/reboot/examples/reboot-swag-store/BUILD.bazel
@@ -85,12 +85,6 @@ sh_test_in_working_directory(
     # is generated from are copied into the test sandbox; the script
     # `cd`s into `frontend/` itself.
     script = "frontend/.tests/type_check.sh",
-    # `tsc` and the frontend bundler produce the same result on MacOS
-    # as on Linux, and the `rbt generate` and `npm install` steps on
-    # the way there are exercised on MacOS by
-    # `//tests/reboot/examples/chat-room:test` and
-    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     working_directory = "reboot/examples/reboot-swag-store/",
 )

--- a/tests/reboot/examples/reboot-swag-store/BUILD.bazel
+++ b/tests/reboot/examples/reboot-swag-store/BUILD.bazel
@@ -85,5 +85,12 @@ sh_test_in_working_directory(
     # is generated from are copied into the test sandbox; the script
     # `cd`s into `frontend/` itself.
     script = "frontend/.tests/type_check.sh",
+    # `tsc` and the frontend bundler produce the same result on MacOS
+    # as on Linux, and the `rbt generate` and `npm install` steps on
+    # the way there are exercised on MacOS by
+    # `//tests/reboot/examples/chat-room:test` and
+    # `//tests/reboot/examples/chat-room-nodejs:test`, which keep
+    # running there.
+    tags = ["platform-independent"],
     working_directory = "reboot/examples/reboot-swag-store/",
 )

--- a/tests/reboot/react/test_cache/BUILD.bazel
+++ b/tests/reboot/react/test_cache/BUILD.bazel
@@ -137,14 +137,7 @@ vitest_test(
     # from.
     env = {"REBOOT_WHL_FILE": "$(rootpath //reboot:reboot.dev)"},
     node_modules = "//:node_modules",
-    # The React client logic under test runs in `vitest` under
-    # `jsdom`, with no browser involved; the `chromium` `web_test`s in
-    # `//tests/reboot/react/...` carry `macos_not_supported`. The
-    # Reboot backend and LocalEnvoy that `rbt.up()` starts are
-    # exercised on MacOS by
-    # `//tests/reboot/nodejs/reboot_web_test:test`, which keeps
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     visibility = ["//visibility:public"],
 )
 
@@ -163,14 +156,7 @@ vitest_test(
     # from.
     env = {"REBOOT_WHL_FILE": "$(rootpath //reboot:reboot.dev)"},
     node_modules = "//:node_modules",
-    # The React client logic under test runs in `vitest` under
-    # `jsdom`, with no browser involved; the `chromium` `web_test`s in
-    # `//tests/reboot/react/...` carry `macos_not_supported`. The
-    # Reboot backend and LocalEnvoy that `rbt.up()` starts are
-    # exercised on MacOS by
-    # `//tests/reboot/nodejs/reboot_web_test:test`, which keeps
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     visibility = ["//visibility:public"],
 )
 
@@ -189,14 +175,7 @@ vitest_test(
     # from.
     env = {"REBOOT_WHL_FILE": "$(rootpath //reboot:reboot.dev)"},
     node_modules = "//:node_modules",
-    # The React client logic under test runs in `vitest` under
-    # `jsdom`, with no browser involved; the `chromium` `web_test`s in
-    # `//tests/reboot/react/...` carry `macos_not_supported`. The
-    # Reboot backend and LocalEnvoy that `rbt.up()` starts are
-    # exercised on MacOS by
-    # `//tests/reboot/nodejs/reboot_web_test:test`, which keeps
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     visibility = ["//visibility:public"],
 )
 

--- a/tests/reboot/react/test_cache/BUILD.bazel
+++ b/tests/reboot/react/test_cache/BUILD.bazel
@@ -137,6 +137,14 @@ vitest_test(
     # from.
     env = {"REBOOT_WHL_FILE": "$(rootpath //reboot:reboot.dev)"},
     node_modules = "//:node_modules",
+    # The React client logic under test runs in `vitest` under
+    # `jsdom`, with no browser involved; the `chromium` `web_test`s in
+    # `//tests/reboot/react/...` carry `macos_not_supported`. The
+    # Reboot backend and LocalEnvoy that `rbt.up()` starts are
+    # exercised on MacOS by
+    # `//tests/reboot/nodejs/reboot_web_test:test`, which keeps
+    # running there.
+    tags = ["platform-independent"],
     visibility = ["//visibility:public"],
 )
 
@@ -155,6 +163,14 @@ vitest_test(
     # from.
     env = {"REBOOT_WHL_FILE": "$(rootpath //reboot:reboot.dev)"},
     node_modules = "//:node_modules",
+    # The React client logic under test runs in `vitest` under
+    # `jsdom`, with no browser involved; the `chromium` `web_test`s in
+    # `//tests/reboot/react/...` carry `macos_not_supported`. The
+    # Reboot backend and LocalEnvoy that `rbt.up()` starts are
+    # exercised on MacOS by
+    # `//tests/reboot/nodejs/reboot_web_test:test`, which keeps
+    # running there.
+    tags = ["platform-independent"],
     visibility = ["//visibility:public"],
 )
 
@@ -173,6 +189,14 @@ vitest_test(
     # from.
     env = {"REBOOT_WHL_FILE": "$(rootpath //reboot:reboot.dev)"},
     node_modules = "//:node_modules",
+    # The React client logic under test runs in `vitest` under
+    # `jsdom`, with no browser involved; the `chromium` `web_test`s in
+    # `//tests/reboot/react/...` carry `macos_not_supported`. The
+    # Reboot backend and LocalEnvoy that `rbt.up()` starts are
+    # exercised on MacOS by
+    # `//tests/reboot/nodejs/reboot_web_test:test`, which keeps
+    # running there.
+    tags = ["platform-independent"],
     visibility = ["//visibility:public"],
 )
 

--- a/tests/reboot/react/test_mutations/BUILD.bazel
+++ b/tests/reboot/react/test_mutations/BUILD.bazel
@@ -51,6 +51,11 @@ js_reboot_react_library(
 # might want to revisit this).
 build_test(
     name = "test_build_no_mutations",
+    # Compiling generated TypeScript behaves the same on MacOS as on
+    # Linux, and generating a React client is exercised on MacOS by
+    # `//tests/reboot/cli/generate:react_out_specified_tests_py`,
+    # which keeps running there.
+    tags = ["platform-independent"],
     targets = [":test_js_reboot_react"],
 )
 

--- a/tests/reboot/react/test_mutations/BUILD.bazel
+++ b/tests/reboot/react/test_mutations/BUILD.bazel
@@ -51,11 +51,7 @@ js_reboot_react_library(
 # might want to revisit this).
 build_test(
     name = "test_build_no_mutations",
-    # Compiling generated TypeScript behaves the same on MacOS as on
-    # Linux, and generating a React client is exercised on MacOS by
-    # `//tests/reboot/cli/generate:react_out_specified_tests_py`,
-    # which keeps running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     targets = [":test_js_reboot_react"],
 )
 

--- a/tests/reboot/react/test_ordered_map/BUILD.bazel
+++ b/tests/reboot/react/test_ordered_map/BUILD.bazel
@@ -47,5 +47,13 @@ vitest_test(
     # from.
     env = {"REBOOT_WHL_FILE": "$(rootpath //reboot:reboot.dev)"},
     node_modules = "//:node_modules",
+    # The React client logic under test runs in `vitest` under
+    # `jsdom`, with no browser involved; the `chromium` `web_test`s in
+    # `//tests/reboot/react/...` carry `macos_not_supported`. The
+    # Reboot backend and LocalEnvoy that `rbt.up()` starts are
+    # exercised on MacOS by
+    # `//tests/reboot/nodejs/reboot_web_test:test`, which keeps
+    # running there.
+    tags = ["platform-independent"],
     visibility = ["//visibility:public"],
 )

--- a/tests/reboot/react/test_ordered_map/BUILD.bazel
+++ b/tests/reboot/react/test_ordered_map/BUILD.bazel
@@ -47,13 +47,6 @@ vitest_test(
     # from.
     env = {"REBOOT_WHL_FILE": "$(rootpath //reboot:reboot.dev)"},
     node_modules = "//:node_modules",
-    # The React client logic under test runs in `vitest` under
-    # `jsdom`, with no browser involved; the `chromium` `web_test`s in
-    # `//tests/reboot/react/...` carry `macos_not_supported`. The
-    # Reboot backend and LocalEnvoy that `rbt.up()` starts are
-    # exercised on MacOS by
-    # `//tests/reboot/nodejs/reboot_web_test:test`, which keeps
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     visibility = ["//visibility:public"],
 )

--- a/tests/reboot/react/test_state_id_change/BUILD.bazel
+++ b/tests/reboot/react/test_state_id_change/BUILD.bazel
@@ -49,13 +49,6 @@ vitest_test(
     # from.
     env = {"REBOOT_WHL_FILE": "$(rootpath //reboot:reboot.dev)"},
     node_modules = "//:node_modules",
-    # The React client logic under test runs in `vitest` under
-    # `jsdom`, with no browser involved; the `chromium` `web_test`s in
-    # `//tests/reboot/react/...` carry `macos_not_supported`. The
-    # Reboot backend and LocalEnvoy that `rbt.up()` starts are
-    # exercised on MacOS by
-    # `//tests/reboot/nodejs/reboot_web_test:test`, which keeps
-    # running there.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     visibility = ["//visibility:public"],
 )

--- a/tests/reboot/react/test_state_id_change/BUILD.bazel
+++ b/tests/reboot/react/test_state_id_change/BUILD.bazel
@@ -49,5 +49,13 @@ vitest_test(
     # from.
     env = {"REBOOT_WHL_FILE": "$(rootpath //reboot:reboot.dev)"},
     node_modules = "//:node_modules",
+    # The React client logic under test runs in `vitest` under
+    # `jsdom`, with no browser involved; the `chromium` `web_test`s in
+    # `//tests/reboot/react/...` carry `macos_not_supported`. The
+    # Reboot backend and LocalEnvoy that `rbt.up()` starts are
+    # exercised on MacOS by
+    # `//tests/reboot/nodejs/reboot_web_test:test`, which keeps
+    # running there.
+    tags = ["platform-independent"],
     visibility = ["//visibility:public"],
 )

--- a/tests/reboot/state_manager_tests.py
+++ b/tests/reboot/state_manager_tests.py
@@ -1131,6 +1131,236 @@ class LockTest(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(lock.is_exclusive_locked())
         lock.release_shared()
 
+    async def test_cancelled_exclusive_waiter_leaves_lock_free(self) -> None:
+        """A queued exclusive waiter whose task is cancelled before it
+        is granted must not be handed the exclusive hold. Its acquire
+        can only raise from here on, so nothing will ever release that
+        hold: the lock would stay held by nobody for the life of the
+        process, and every later acquire on this state would fail or
+        block forever."""
+        lock = Lock()
+        await lock.acquire_shared(deadline=None)
+
+        async def exclusive() -> None:
+            await lock.acquire_exclusive(deadline=None)
+            lock.release_exclusive()
+
+        exclusive_task = asyncio.create_task(exclusive())
+        # One `sleep(0)` is enough to leave the task queued on the
+        # lock. `create_task()` puts the task's first run on the event
+        # loop's ready queue, and `sleep(0)` puts this coroutine's own
+        # continuation on that same queue behind it; the queue is
+        # first in, first out, so the task runs before we resume. That
+        # first run carries the task to its first suspension, which is
+        # `Lock._wait()` awaiting the waiter's future -- everything
+        # ahead of that, putting the waiter on the lock's queue
+        # included, is synchronous.
+        await asyncio.sleep(0)
+
+        exclusive_task.cancel()
+        lock.release_shared()
+        with self.assertRaises(asyncio.CancelledError):
+            await exclusive_task
+
+        self.assertFalse(lock.is_locked())
+        # The lock is genuinely free, i.e., a fresh acquire is granted
+        # right away rather than queueing behind a holder that is not
+        # there.
+        self.assertTrue(lock.try_acquire_exclusive())
+        lock.release_exclusive()
+
+    async def test_cancelled_shared_waiter_leaves_lock_free(self) -> None:
+        """The shared counterpart: a cancelled shared waiter must not
+        be counted as a holder. It would be counted for the life of
+        the process, blocking every later exclusive acquire and every
+        upgrade on this state forever."""
+        lock = Lock()
+        await lock.acquire_exclusive(deadline=None)
+
+        async def shared() -> None:
+            await lock.acquire_shared(deadline=None)
+            lock.release_shared()
+
+        shared_task = asyncio.create_task(shared())
+        # Runs the task up to queueing on the lock.
+        await asyncio.sleep(0)
+
+        shared_task.cancel()
+        lock.release_exclusive()
+        with self.assertRaises(asyncio.CancelledError):
+            await shared_task
+
+        self.assertFalse(lock.is_locked())
+        self.assertTrue(lock.try_acquire_exclusive())
+        lock.release_exclusive()
+
+    async def test_cancelled_upgrader_leaves_lock_shared(self) -> None:
+        """A cancelled upgrader must not be handed the exclusive hold
+        either, which would wedge the lock exclusively forever. It
+        keeps the shared hold it was upgrading from."""
+        lock = Lock()
+        # Two shared holders, so the upgrade has to queue.
+        await lock.acquire_shared(deadline=None)
+        await lock.acquire_shared(deadline=None)
+
+        async def upgrader() -> None:
+            await lock.upgrade(deadline=None)
+            lock.release_exclusive()
+
+        upgrader_task = asyncio.create_task(upgrader())
+        # Runs the task up to queueing the upgrade on the lock.
+        await asyncio.sleep(0)
+
+        upgrader_task.cancel()
+        # Releasing leaves a single shared holder, which is exactly the
+        # condition under which a pending upgrade is granted.
+        lock.release_shared()
+        with self.assertRaises(asyncio.CancelledError):
+            await upgrader_task
+
+        self.assertTrue(lock.is_shared_locked())
+        self.assertFalse(lock.is_exclusive_locked())
+        lock.release_shared()
+        self.assertFalse(lock.is_locked())
+
+    async def test_cancelled_granted_upgrader_keeps_its_shared_hold(
+        self,
+    ) -> None:
+        """An upgrade that is granted and whose caller is then
+        interrupted before it can use the exclusive hold leaves that
+        caller believing it still holds shared, so that is what the
+        lock must be left holding. Releasing the exclusive hold
+        outright instead would drop a shared hold its caller still
+        owes, and that caller's later release would assert."""
+        lock = Lock()
+        await lock.acquire_shared(deadline=None)
+        await lock.acquire_shared(deadline=None)
+
+        async def upgrader() -> None:
+            await lock.upgrade(deadline=None)
+            lock.release_exclusive()
+
+        upgrader_task = asyncio.create_task(upgrader())
+        # Runs the task up to queueing the upgrade on the lock.
+        await asyncio.sleep(0)
+
+        # Grant the upgrade, then interrupt its caller before it gets
+        # a chance to run again.
+        lock.release_shared()
+        self.assertTrue(lock.is_exclusive_locked())
+        upgrader_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await upgrader_task
+
+        self.assertTrue(lock.is_shared_locked())
+        self.assertFalse(lock.is_exclusive_locked())
+        lock.release_shared()
+        self.assertFalse(lock.is_locked())
+
+    async def test_cancelled_upgrader_leaves_a_later_upgrade_alone(
+        self,
+    ) -> None:
+        """A cancelled upgrader is dropped from the upgrade slot as
+        soon as a release notices it, which frees the slot for another
+        holder to register an upgrade of its own. When the cancelled
+        one is resumed to clean up after itself it must leave that
+        later upgrade in place: emptying the slot would leave the
+        later upgrade registered nowhere, so nothing could ever grant
+        it and its caller would wait out its whole acquire deadline
+        for a hold that was free the entire time."""
+        lock = Lock()
+        # A shared hold each for this test, the cancelled upgrader and
+        # the later upgrader, so that neither upgrade is ever the sole
+        # holder and both have to queue.
+        await lock.acquire_shared(deadline=None)
+
+        async def cancelled_upgrader() -> None:
+            await lock.acquire_shared(deadline=None)
+            try:
+                await lock.upgrade(deadline=None)
+            except BaseException:
+                # An upgrade that fails leaves its caller holding the
+                # shared hold it was upgrading from.
+                lock.release_shared()
+                raise
+            lock.release_exclusive()
+
+        cancelled_task = asyncio.create_task(cancelled_upgrader())
+        # Runs the task up to registering its upgrade.
+        await asyncio.sleep(0)
+
+        async def later_upgrader() -> None:
+            await lock.acquire_shared(deadline=None)
+            # A deadline rather than `None`, so that an upgrade left
+            # registered nowhere fails this test rather than hanging
+            # the suite. The upgrade is granted while the cancelled
+            # upgrader unwinds, well within it.
+            await lock.upgrade(deadline=timedelta(seconds=5))
+            lock.release_exclusive()
+
+        # Everything from here to the `sleep(0)` below is synchronous,
+        # which is what fixes the order the event loop runs these in:
+        # the later upgrader's first run is queued first, the
+        # cancelled upgrader's wake-up second, and this coroutine's
+        # own continuation last, on a first in, first out queue.
+        later_task = asyncio.create_task(later_upgrader())
+        cancelled_task.cancel()
+        # Releasing notices the cancelled upgrade and empties the
+        # slot, leaving it free for the later upgrader to claim.
+        lock.release_shared()
+
+        # Runs the later upgrader, which takes a shared hold and
+        # registers its upgrade in the free slot, and then the
+        # cancelled upgrader, which cleans up and hands back its own
+        # shared hold, leaving the later upgrade the only reason this
+        # lock is still held.
+        await asyncio.sleep(0)
+
+        with self.assertRaises(asyncio.CancelledError):
+            await cancelled_task
+
+        # The later upgrade was granted as the cancelled upgrader
+        # unwound, so this returns rather than timing out.
+        await later_task
+        self.assertFalse(lock.is_locked())
+
+    async def test_waiter_queued_behind_a_cancelled_one_is_granted(
+        self,
+    ) -> None:
+        """Dropping a cancelled waiter lets whoever queued behind it
+        through, rather than stalling the rest of the queue."""
+        lock = Lock()
+        await lock.acquire_exclusive(deadline=None)
+
+        async def cancelled_shared() -> None:
+            await lock.acquire_shared(deadline=None)
+            lock.release_shared()
+
+        cancelled_task = asyncio.create_task(cancelled_shared())
+        # Runs the task up to queueing on the lock.
+        await asyncio.sleep(0)
+
+        shared_acquired = asyncio.Event()
+
+        async def shared() -> None:
+            await lock.acquire_shared(deadline=None)
+            shared_acquired.set()
+
+        shared_task = asyncio.create_task(shared())
+        # Runs the task up to queueing behind the first one.
+        await asyncio.sleep(0)
+
+        cancelled_task.cancel()
+        lock.release_exclusive()
+        with self.assertRaises(asyncio.CancelledError):
+            await cancelled_task
+
+        await shared_acquired.wait()
+        await shared_task
+        self.assertTrue(lock.is_shared_locked())
+        lock.release_shared()
+        self.assertFalse(lock.is_locked())
+
 
 class EffectsRequiresExclusiveTest(unittest.TestCase):
     """Unit tests for `Effects.requires_exclusive()`, which decides

--- a/tests/reboot/state_manager_tests.py
+++ b/tests/reboot/state_manager_tests.py
@@ -1131,13 +1131,38 @@ class LockTest(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(lock.is_exclusive_locked())
         lock.release_shared()
 
+    async def test_upgrade_deadline_raises_unavailable(self) -> None:
+        lock = Lock()
+        # Two shared holders, so the upgrade has to queue, and nothing
+        # releases while it waits, so it runs out its deadline.
+        await lock.acquire_shared(deadline=None)
+        await lock.acquire_shared(deadline=None)
+        with self.assertRaises(SystemAborted) as aborted:
+            await lock.upgrade(deadline=timedelta(seconds=0.05))
+        self.assertEqual(type(aborted.exception.error), Unavailable)
+        # An upgrade that fails leaves its caller holding the shared
+        # hold it was upgrading from.
+        self.assertTrue(lock.is_shared_locked())
+        self.assertFalse(lock.is_exclusive_locked())
+        # It also leaves the upgrade slot free, so a second attempt
+        # gets as far as waiting out a deadline of its own rather than
+        # being turned away because somebody is already upgrading.
+        with self.assertRaises(SystemAborted) as aborted:
+            await lock.upgrade(deadline=timedelta(seconds=0.05))
+        assert aborted.exception.message is not None
+        self.assertIn("Timed out waiting", aborted.exception.message)
+        lock.release_shared()
+        lock.release_shared()
+        self.assertFalse(lock.is_locked())
+
     async def test_cancelled_exclusive_waiter_leaves_lock_free(self) -> None:
-        """A queued exclusive waiter whose task is cancelled before it
-        is granted must not be handed the exclusive hold. Its acquire
-        can only raise from here on, so nothing will ever release that
-        hold: the lock would stay held by nobody for the life of the
-        process, and every later acquire on this state would fail or
-        block forever."""
+        """A queued exclusive waiter whose task is cancelled can still
+        be handed the exclusive hold, because the release that grants
+        it can land before the waiter is resumed. Its acquire can only
+        raise from here on, so it has to hand that hold back on its
+        way out: nothing else ever will, and a lock held by nobody
+        stays that way for the life of the process, failing or
+        blocking every later acquire on the state it guards."""
         lock = Lock()
         await lock.acquire_shared(deadline=None)
 
@@ -1170,10 +1195,11 @@ class LockTest(unittest.IsolatedAsyncioTestCase):
         lock.release_exclusive()
 
     async def test_cancelled_shared_waiter_leaves_lock_free(self) -> None:
-        """The shared counterpart: a cancelled shared waiter must not
-        be counted as a holder. It would be counted for the life of
-        the process, blocking every later exclusive acquire and every
-        upgrade on this state forever."""
+        """The shared counterpart: a cancelled shared waiter that is
+        counted as a holder on its way out has to hand that back just
+        the same. A shared hold nobody releases is counted for the
+        life of the process, blocking every later exclusive acquire
+        and every upgrade on this state forever."""
         lock = Lock()
         await lock.acquire_exclusive(deadline=None)
 
@@ -1195,9 +1221,10 @@ class LockTest(unittest.IsolatedAsyncioTestCase):
         lock.release_exclusive()
 
     async def test_cancelled_upgrader_leaves_lock_shared(self) -> None:
-        """A cancelled upgrader must not be handed the exclusive hold
-        either, which would wedge the lock exclusively forever. It
-        keeps the shared hold it was upgrading from."""
+        """A cancelled upgrader that is handed the exclusive hold has
+        to give it back too, or the lock is wedged exclusively
+        forever. What it gives back is the shared hold it was
+        upgrading from, which its caller still believes it holds."""
         lock = Lock()
         # Two shared holders, so the upgrade has to queue.
         await lock.acquire_shared(deadline=None)
@@ -1257,21 +1284,19 @@ class LockTest(unittest.IsolatedAsyncioTestCase):
         lock.release_shared()
         self.assertFalse(lock.is_locked())
 
-    async def test_cancelled_upgrader_leaves_a_later_upgrade_alone(
+    async def test_cancelled_upgrader_lets_the_next_waiter_through(
         self,
     ) -> None:
-        """A cancelled upgrader is dropped from the upgrade slot as
-        soon as a release notices it, which frees the slot for another
-        holder to register an upgrade of its own. When the cancelled
-        one is resumed to clean up after itself it must leave that
-        later upgrade in place: emptying the slot would leave the
-        later upgrade registered nowhere, so nothing could ever grant
-        it and its caller would wait out its whole acquire deadline
-        for a hold that was free the entire time."""
+        """Handing a hold back is not the end of a cancelled waiter's
+        obligations: the hold has to reach whoever is queued behind
+        it. A cancelled upgrader gives back a shared hold rather than
+        an exclusive one, so the release that carries it onwards is
+        the `downgrade()`, and what it has to carry is every waiter a
+        shared holder is compatible with."""
         lock = Lock()
         # A shared hold each for this test, the cancelled upgrader and
-        # the later upgrader, so that neither upgrade is ever the sole
-        # holder and both have to queue.
+        # the later upgrader, so that the upgrade this test cancels
+        # has to queue rather than being granted on the spot.
         await lock.acquire_shared(deadline=None)
 
         async def cancelled_upgrader() -> None:
@@ -1290,11 +1315,12 @@ class LockTest(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
 
         async def later_upgrader() -> None:
-            await lock.acquire_shared(deadline=None)
-            # A deadline rather than `None`, so that an upgrade left
-            # registered nowhere fails this test rather than hanging
-            # the suite. The upgrade is granted while the cancelled
-            # upgrader unwinds, well within it.
+            # A deadline rather than `None`, so that a hold that never
+            # reaches this waiter fails this test rather than hanging
+            # the suite. The shared hold is granted while the cancelled
+            # upgrader unwinds and the upgrade right after it, both
+            # well within these.
+            await lock.acquire_shared(deadline=timedelta(seconds=5))
             await lock.upgrade(deadline=timedelta(seconds=5))
             lock.release_exclusive()
 
@@ -1305,30 +1331,32 @@ class LockTest(unittest.IsolatedAsyncioTestCase):
         # own continuation last, on a first in, first out queue.
         later_task = asyncio.create_task(later_upgrader())
         cancelled_task.cancel()
-        # Releasing notices the cancelled upgrade and empties the
-        # slot, leaving it free for the later upgrader to claim.
+        # Leaves the cancelled upgrader the sole shared holder, which
+        # is exactly the condition under which its upgrade is granted
+        # -- cancelled or not, it has not been resumed to say so.
         lock.release_shared()
 
-        # Runs the later upgrader, which takes a shared hold and
-        # registers its upgrade in the free slot, and then the
-        # cancelled upgrader, which cleans up and hands back its own
-        # shared hold, leaving the later upgrade the only reason this
-        # lock is still held.
+        # Runs the later upgrader, which queues for a shared hold
+        # behind the exclusive one the cancelled upgrader now holds,
+        # and then the cancelled upgrader, which downgrades -- which
+        # is what grants that queued shared hold -- and then hands
+        # back its own, leaving the later upgrader the only holder.
         await asyncio.sleep(0)
 
         with self.assertRaises(asyncio.CancelledError):
             await cancelled_task
 
-        # The later upgrade was granted as the cancelled upgrader
-        # unwound, so this returns rather than timing out.
+        # The later upgrader was carried through by the cancelled
+        # one's unwinding, so this returns rather than timing out.
         await later_task
         self.assertFalse(lock.is_locked())
 
     async def test_waiter_queued_behind_a_cancelled_one_is_granted(
         self,
     ) -> None:
-        """Dropping a cancelled waiter lets whoever queued behind it
-        through, rather than stalling the rest of the queue."""
+        """A cancelled waiter at the head of the queue does not stall
+        the waiters behind it: they are granted alongside it, and the
+        hold it hands back on its way out is its own."""
         lock = Lock()
         await lock.acquire_exclusive(deadline=None)
 

--- a/tests/reboot/std/collections/ordered_map/v1/BUILD.bazel
+++ b/tests/reboot/std/collections/ordered_map/v1/BUILD.bazel
@@ -7,12 +7,7 @@ py_test(
     size = "large",
     srcs = [":ordered_map_tests.py"],
     main = "ordered_map_tests.py",
-    # This exercises the `OrderedMap` B-tree logic on top of the
-    # in-process `Reboot()` test harness, neither of which behaves
-    # differently on MacOS; the storage engine underneath is
-    # exercised on MacOS by `//tests/reboot/server:database_tests`
-    # and `//tests/reboot:state_manager_tests_py`.
-    tags = ["platform-independent"],
+    tags = ["macos-nightly-only"],
     deps = [
         "//rbt/std/item/v1:item_py_reboot",
         "//reboot:protobuf_py",

--- a/tests/reboot/std/collections/ordered_map/v1/BUILD.bazel
+++ b/tests/reboot/std/collections/ordered_map/v1/BUILD.bazel
@@ -7,6 +7,12 @@ py_test(
     size = "large",
     srcs = [":ordered_map_tests.py"],
     main = "ordered_map_tests.py",
+    # This exercises the `OrderedMap` B-tree logic on top of the
+    # in-process `Reboot()` test harness, neither of which behaves
+    # differently on MacOS; the storage engine underneath is
+    # exercised on MacOS by `//tests/reboot/server:database_tests`
+    # and `//tests/reboot:state_manager_tests_py`.
+    tags = ["platform-independent"],
     deps = [
         "//rbt/std/item/v1:item_py_reboot",
         "//reboot:protobuf_py",

--- a/tests/reboot/zod/concurrent_transactions_same_state/BUILD.bazel
+++ b/tests/reboot/zod/concurrent_transactions_same_state/BUILD.bazel
@@ -55,6 +55,12 @@ ts_project(
 
 js_reboot_test(
     name = "test",
+    # A Node test builds a Python virtualenv and `pip install`s the
+    # Reboot wheel into it before any of the test body runs. On the
+    # MacOS arm64 CI runner that alone has taken the whole 300s a
+    # `medium` test gets, killing the test before it started, so this
+    # one gets the 900s of a `large` test to work in.
+    size = "large",
     data = [
         ":test_ts",
     ],


### PR DESCRIPTION
CI is currently ~unpassable because of CI flakes. Most notably `//tests/reboot/pydantic/concurrent_transactions_same_state:test_py` is ~80% flaky. An agent identified two hangs in the transaction code from those flakes. These each have their own commit to fix them, please see the individual commit descriptions for details.

Additionally, we address timeouts and flakes in MacOS CI that are due to overload by reducing its workload, removing tests that don't add meaningful coverage.

Note that while the first commit's case is proven with unit tests, the second is hard to repro so needs some human reasoning to validate.