### PR TITLE
auth: let the Ory provider send the browser to a separate origin

### DIFF
--- a/reboot/aio/auth/oauth_providers.py
+++ b/reboot/aio/auth/oauth_providers.py
@@ -115,6 +115,30 @@ def _normalize_domain(domain: Optional[str]) -> str:
     return host.strip("/")
 
 
+def _normalize_browser_facing_url(url: Optional[str]) -> Optional[str]:
+    """Validate an `Ory(browser_facing_url=...)` and reduce it to a
+    bare origin. Unlike `domain`, this is the browser's own address
+    for Ory (e.g. a local `ory tunnel`), so it must carry a scheme and
+    host — optionally a port — and no path, or `{url}/oauth2/auth`
+    would be a nonsense endpoint. Returns `None` for a missing value.
+    """
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if (
+        parsed.scheme not in ("http", "https") or not parsed.netloc or
+        parsed.path.strip("/") or parsed.query or parsed.fragment
+    ):
+        raise InputError(
+            reason=(
+                f"`Ory` got a `browser_facing_url={url!r}` that is not a "
+                "bare origin. Pass a scheme, host, and optional port with "
+                "no path, e.g. `http://localhost:4000`."
+            ),
+        )
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
 def _decoded_id_token(
     id_token: Optional[str],
 ) -> Optional[dict[str, Any]]:
@@ -1153,8 +1177,8 @@ class Ory(RegisteredOAuthProvider):
             )
         self._domain = _normalize_domain(domain)
         self._webhook_secret = webhook_secret
-        self._browser_facing_url = (
-            browser_facing_url.rstrip("/") if browser_facing_url else None
+        self._browser_facing_url = _normalize_browser_facing_url(
+            browser_facing_url
         )
 
     @property

--- a/reboot/aio/auth/oauth_providers.py
+++ b/reboot/aio/auth/oauth_providers.py
@@ -1118,6 +1118,17 @@ class Ory(RegisteredOAuthProvider):
         # `client_secret` — from a secret store / environment secret,
         # never a hard-coded literal.
         webhook_secret: Optional[str] = None,
+        # Base URL the browser is sent to for the OAuth2
+        # authorization request, for the case where the browser
+        # reaches Ory at a different origin than `domain`. In local
+        # development the browser reaches Ory through an `ory tunnel`
+        # (e.g. `http://localhost:4000`) so Ory's cookies are
+        # same-site with the app and the whole login flow shares one
+        # cookie jar; the server still uses `domain` for the
+        # server-to-server token exchange. A full base URL (scheme,
+        # host, optionally a port), no trailing path; defaults to
+        # `https://{domain}`.
+        browser_facing_url: Optional[str] = None,
     ):
         super().__init__(
             client_id=client_id,
@@ -1142,10 +1153,17 @@ class Ory(RegisteredOAuthProvider):
             )
         self._domain = _normalize_domain(domain)
         self._webhook_secret = webhook_secret
+        self._browser_facing_url = (
+            browser_facing_url.rstrip("/") if browser_facing_url else None
+        )
 
     @property
     def _authorization_endpoint(self) -> str:
-        return f"https://{self._domain}/oauth2/auth"
+        # The browser hits this one, so it honors `browser_facing_url`
+        # when the browser reaches Ory at a different origin than the
+        # server does.
+        base = self._browser_facing_url or f"https://{self._domain}"
+        return f"{base}/oauth2/auth"
 
     @property
     def _token_endpoint(self) -> str:

--- a/tests/reboot/aio/auth/oauth_providers_test.py
+++ b/tests/reboot/aio/auth/oauth_providers_test.py
@@ -1642,6 +1642,38 @@ class OryDomainTest(unittest.TestCase):
             url.startswith("https://slug.projects.oryapis.com/oauth2/auth?")
         )
 
+    def test_browser_facing_url_overrides_only_the_authorize_host(self):
+        # `browser_facing_url` sends the browser to a different origin
+        # (e.g. a local `ory tunnel`) for the authorize redirect, while
+        # the server keeps reaching Ory at `domain` for the token
+        # exchange.
+        ory = Ory(
+            domain="slug.projects.oryapis.com",
+            client_id="id",
+            client_secret="s",
+            browser_facing_url="http://localhost:4000",
+        )
+        url = ory.authorization_url(
+            state="x", redirect_uri="http://localhost/cb"
+        )
+        self.assertTrue(url.startswith("http://localhost:4000/oauth2/auth?"))
+        self.assertEqual(
+            ory._token_endpoint,
+            "https://slug.projects.oryapis.com/oauth2/token",
+        )
+
+    def test_browser_facing_url_must_be_a_bare_origin(self):
+        # A path or a missing scheme would make `{url}/oauth2/auth` a
+        # nonsense endpoint, so those are rejected up front.
+        for bad in ("localhost:4000", "http://localhost:4000/foo"):
+            with self.assertRaises(InputError):
+                Ory(
+                    domain="slug.projects.oryapis.com",
+                    client_id="id",
+                    client_secret="s",
+                    browser_facing_url=bad,
+                )
+
 
 def _ory(**kwargs: Any) -> Ory:
     """An `Ory` with throwaway credentials, for tests that only


### PR DESCRIPTION
The Ory OAuth provider hardcoded the browser's authorization redirect to `https://{domain}/oauth2/auth` — the same host it uses server-side for the token exchange. Local development needs the browser to reach Ory through an `ory tunnel` (e.g. `http://localhost:4000`), so Ory's cookies are same-site with the app and the whole OAuth2 login flow shares one cookie jar, while the server still reaches Ory at `domain`.

This adds an optional `browser_facing_url` that overrides only the browser-facing authorization endpoint. It defaults to `https://{domain}`, so existing deployments are unchanged.
