### PR TITLE
Properly escape specific symbols in TS

### DIFF
--- a/rbt/v1alpha1/index.ts
+++ b/rbt/v1alpha1/index.ts
@@ -979,20 +979,28 @@ type StateId = string;
 type StateRef = string;
 type StateTypeName = string;
 
-// Corresponds to encodings in `reboot.aio.types`.
+// The characters a state ID may not contain.
+//
+// NOTE: this is a copy of `ILLEGAL_STATE_ID_CHARACTERS` in
+// `public/reboot/aio/types.py`; keep the two lists in sync.
+const ILLEGAL_STATE_ID_CHARACTERS = "\0\n\\";
+
+// Corresponds to encodings in `reboot.aio.types`, plus the
+// percent-encoding that carries a state ref inside a URL path.
 export function stateIdToRef(stateType: StateTypeName, id: StateId): StateRef {
   // This is the earliest time we can validate the state ID given to us by the
   // user; do it now, so that any stack trace is as short as possible.
-  validateASCII(id, "state ID", 1, 128);
+  validateASCII(id, "state ID", 1, 128, ILLEGAL_STATE_ID_CHARACTERS);
 
+  // A `/` separates the components of a colocated state ref, so a `/`
+  // within a single ID is escaped to a `\` first, matching
+  // `_state_id_encode` in `public/reboot/aio/types.py`.
   const escapedKey = id.replace(/\//g, "\\");
 
-  // Need to encode backslashes, because the TypeScript built-in 'URL'
-  // class will escape back any backslashes to forward slashes.
-  // We can't escape a forward slash with '%2F' currently, because we
-  // use forward slashes in the collocations.
-  // See more at public/reboot/aio/types.py.
-  const encoded = escapedKey.replace(/\\/g, "%5C");
+  // A state ref is interpolated into a URL path, so percent-encode the
+  // whole ID rather than only the characters the `URL` class is known
+  // to mangle.
+  const encoded = encodeURIComponent(escapedKey);
   return `${stateType}:${encoded}`;
 }
 
@@ -1001,7 +1009,8 @@ function validateASCII(
   s: string,
   fieldDescription: string,
   lengthMin: number = 0,
-  lengthMax?: number
+  lengthMax?: number,
+  illegalCharacters: string = ""
 ) {
   if (s.length < lengthMin) {
     throw new Error(
@@ -1024,6 +1033,17 @@ function validateASCII(
         `${fieldDescription} must be ASCII; given value '${s}' is not ASCII`
       );
     }
+  }
+
+  const found = [...s].filter((character) =>
+    illegalCharacters.includes(character)
+  );
+  if (found.length > 0) {
+    throw new Error(
+      `${fieldDescription} must not contain any of ` +
+        `${JSON.stringify(illegalCharacters)}; given value ` +
+        `${JSON.stringify(s)} contains ${JSON.stringify(found.join(""))}`
+    );
   }
 }
 

--- a/reboot/aio/types.py
+++ b/reboot/aio/types.py
@@ -132,7 +132,7 @@ class StateRef:
             'state_id',
             MAX_ACTOR_ID_LENGTH,
             length_min=MIN_ACTOR_ID_LENGTH,
-            illegal_characters="\0\n\\",
+            illegal_characters=ILLEGAL_STATE_ID_CHARACTERS,
             error_type=InvalidStateRefError,
         )
         return StateRef(
@@ -151,7 +151,7 @@ class StateRef:
             'state_id',
             MAX_ACTOR_ID_LENGTH,
             length_min=0,
-            illegal_characters="\0\n\\",
+            illegal_characters=ILLEGAL_STATE_ID_CHARACTERS,
             error_type=InvalidStateRefError,
         )
         return StateRef(
@@ -290,6 +290,16 @@ def state_type_tag_for_name(state_type: StateTypeName) -> StateTypeTag:
         assert len(state_type_tag) == _STATE_TYPE_TAG_LENGTH
         _state_type_tags[state_type] = state_type_tag
     return StateTypeTag(state_type_tag)
+
+
+# The characters a state ID may not contain. A `\` is illegal because
+# `_state_id_encode` spends it escaping a `/`; `\0` and `\n` are
+# illegal because a state ID is carried in a gRPC header.
+#
+# NOTE: there is a TypeScript copy of this list, passed to
+# `validateASCII` by `stateIdToRef` in `rbt/v1alpha1/index.ts`; keep the
+# two lists in sync.
+ILLEGAL_STATE_ID_CHARACTERS = "\0\n\\"
 
 
 def _state_id_encode(state_id: StateId) -> str:

--- a/tests/rbt/v1alpha1/BUILD.bazel
+++ b/tests/rbt/v1alpha1/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@fremtind_rules_vitest//vitest:defs.bzl", "vitest_test")
+
+ts_project(
+    name = "state_id_to_ref_test_ts",
+    srcs = [
+        "state_id_to_ref.test.ts",
+        ":package.json",
+    ],
+    declaration = True,
+    tsconfig = {
+        "compilerOptions": {
+            "declaration": True,
+            "module": "nodenext",
+            "moduleResolution": "nodenext",
+            "skipLibCheck": True,
+            "target": "es2020",
+        },
+    },
+    deps = [
+        "//:node_modules/@reboot-dev/reboot-api",
+        "//reboot/std/vitest:vitest_ts",
+    ],
+)
+
+vitest_test(
+    name = "test",
+    config = "vitest.config.mjs",
+    data = [
+        "package.json",
+        ":state_id_to_ref_test_ts",
+    ],
+    node_modules = "//:node_modules",
+    visibility = ["//visibility:public"],
+)
+
+exports_files(["package.json"])

--- a/tests/rbt/v1alpha1/package.json
+++ b/tests/rbt/v1alpha1/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/rbt/v1alpha1/state_id_to_ref.test.ts
+++ b/tests/rbt/v1alpha1/state_id_to_ref.test.ts
@@ -1,0 +1,108 @@
+// `stateIdToRef` produces the state ref that every JS client
+// interpolates into a `/__/reboot/rpc/<state ref>/...` URL path, and
+// `reboot/routing/filters/mangled_http_path.lua` decodes back out of
+// that path. The `luaDecode` helper below mirrors that filter, so
+// these tests fail when either half drifts from the other.
+import { stateIdToRef } from "@reboot-dev/reboot-api";
+import { describe, expect, it } from "vitest";
+
+const STATE_TYPE = "com.example.Foo";
+
+// Spelled out rather than imported from `ILLEGAL_STATE_ID_CHARACTERS`,
+// so that dropping a character from that constant fails this test
+// instead of quietly narrowing it.
+const ILLEGAL_CHARACTERS = ["\0", "\n", "\\"];
+
+// Every printable ASCII character a state ID is allowed to hold.
+const PRINTABLE_ASCII = Array.from({ length: 0x7e - 0x20 + 1 }, (_, offset) =>
+  String.fromCharCode(0x20 + offset)
+).filter((character) => !ILLEGAL_CHARACTERS.includes(character));
+
+// `mangled_http_path.lua` decodes every `%XX` in one `gsub` pass,
+// which never rescans its own replacements.
+const luaDecode = (stateRef: string): string =>
+  stateRef.replace(/%([0-9A-Fa-f]{2})/g, (_, hex) =>
+    String.fromCharCode(parseInt(hex, 16))
+  );
+
+// The inverse of `_state_id_encode` in `reboot/aio/types.py`, applied
+// to what the Lua filter hands to the `x-reboot-state-ref` header.
+const stateIdSeenByTheServer = (stateRef: string): string =>
+  luaDecode(stateRef.slice(`${STATE_TYPE}:`.length)).replace(/\\/g, "/");
+
+const rpcPath = (stateRef: string): string =>
+  `/__/reboot/rpc/${stateRef}/rbt.v1alpha1.React/Query`;
+
+describe("a state ref carried in a URL path", () => {
+  it("spells out an id that needs no encoding", () => {
+    expect(stateIdToRef(STATE_TYPE, "plain-id")).toBe(
+      "com.example.Foo:plain-id"
+    );
+  });
+
+  it("escapes a slash, which separates colocated components", () => {
+    expect(stateIdToRef(STATE_TYPE, "a/b")).toBe("com.example.Foo:a%5Cb");
+  });
+
+  it("encodes characters that would otherwise end the path", () => {
+    expect(stateIdToRef(STATE_TYPE, "a#b")).toBe("com.example.Foo:a%23b");
+    expect(stateIdToRef(STATE_TYPE, "a?b")).toBe("com.example.Foo:a%3Fb");
+  });
+
+  it("refuses the characters the backend refuses", () => {
+    for (const character of ILLEGAL_CHARACTERS) {
+      expect(() => stateIdToRef(STATE_TYPE, `a${character}b`)).toThrow(
+        /must not contain/
+      );
+    }
+  });
+
+  it.each(PRINTABLE_ASCII)(
+    "leaves the path and the query intact around %j",
+    (character) => {
+      // A raw `#` or `?` truncates the path here, which used to leave
+      // the method segment off the request entirely.
+      const path = rpcPath(stateIdToRef(STATE_TYPE, `a${character}b`));
+      const url = new URL(`https://app.example.com${path}`);
+      expect(url.hash).toBe("");
+      expect(url.search).toBe("");
+      expect(url.pathname).toBe(path);
+    }
+  );
+
+  it.each(PRINTABLE_ASCII)(
+    "names a fragment-free WebSocket URL around %j",
+    (character) => {
+      // `new WebSocket()` throws a `SyntaxError` on any URL carrying a
+      // fragment, so a `#` reaching it unencoded breaks every reactive
+      // reader and every mutation on that state.
+      const url = new URL(
+        `wss://app.example.com` +
+          rpcPath(stateIdToRef(STATE_TYPE, `a${character}b`))
+      );
+      expect(url.hash).toBe("");
+    }
+  );
+
+  it.each(PRINTABLE_ASCII)(
+    "round-trips an id holding %j back to the caller's spelling",
+    (character) => {
+      const id = `a${character}b`;
+      expect(stateIdSeenByTheServer(stateIdToRef(STATE_TYPE, id))).toBe(id);
+    }
+  );
+
+  it("round-trips the ids our own users have run into", () => {
+    for (const id of [
+      // An Auth0 `sub` looks like this.
+      "google-oauth2|1234567890",
+      // A literal `%` must not be read as the start of an escape.
+      "100%25done",
+      "a%23b",
+      // A `/` is the one character with an encoding of its own.
+      "some/nested/path",
+    ]) {
+      expect(stateIdSeenByTheServer(stateIdToRef(STATE_TYPE, id))).toBe(id);
+    }
+  });
+});

--- a/tests/rbt/v1alpha1/vitest.config.mjs
+++ b/tests/rbt/v1alpha1/vitest.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  test: {
+    globals: true,
+    environment: "node",
+  },
+};

--- a/tests/reboot/server/local_envoy_test.py
+++ b/tests/reboot/server/local_envoy_test.py
@@ -17,7 +17,7 @@ from reboot.aio.external import ExternalContext
 from reboot.aio.headers import SERVER_ID_HEADER
 from reboot.aio.interceptors import LegacyGrpcContext
 from reboot.aio.tests import Reboot, temporary_environ
-from reboot.aio.types import StateRef
+from reboot.aio.types import StateRef, StateTypeName
 from reboot.settings import ENVVAR_LOCAL_ENVOY_DEBUG
 from reboot.ssl.localhost import LOCALHOST_CRT_DATA
 from tests.reboot.general_pb2_grpc import (
@@ -30,6 +30,7 @@ from tests.reboot.general_servicer import (
     GeneralResponse,
     GeneralServicer,
 )
+from urllib.parse import quote, urlparse
 
 
 class IdentifierServicer(GeneralServicer):
@@ -106,6 +107,50 @@ class LegacyIdentifierServicer(LegacyGeneralServicer):
             if h[0] == SERVER_ID_HEADER
         )
         return GeneralResponse(content=content)
+
+
+def _reader_path(state_id: str) -> str:
+    """The path a JS client puts on the wire to call
+    `tests.reboot.General`'s `Reader` on `state_id`."""
+    state_type_tag, _, encoded_state_id = StateRef.from_id(
+        StateTypeName('tests.reboot.General'),
+        state_id,
+    ).to_str().partition(':')
+    # Mirrors `stateIdToRef` in `rbt/v1alpha1/index.ts`.
+    return (
+        f"/__/reboot/rpc/{state_type_tag}:{quote(encoded_state_id, safe='')}"
+        "/tests.reboot.GeneralMethods/Reader"
+    )
+
+
+async def _post_exact_path(url: str, path: str) -> tuple[int, bytes]:
+    """POSTs to `path` byte for byte and returns the response's status
+    and body.
+
+    An HTTP client library requotes the path it is given; this does not,
+    so `path` reaches the server spelled exactly as a browser would
+    spell it.
+    """
+    endpoint = urlparse(url)
+    reader, writer = await asyncio.open_connection(
+        endpoint.hostname, endpoint.port
+    )
+    try:
+        writer.write(
+            (
+                f"POST {path} HTTP/1.1\r\n"
+                f"Host: {endpoint.netloc}\r\n"
+                "Content-Length: 0\r\n"
+                "Connection: close\r\n"
+                "\r\n"
+            ).encode()
+        )
+        await writer.drain()
+        head, _, body = (await reader.read()).partition(b"\r\n\r\n")
+        return int(head.split(b" ", 2)[1]), body
+    finally:
+        writer.close()
+        await writer.wait_closed()
 
 
 class LocalEnvoyTestCase(unittest.IsolatedAsyncioTestCase):
@@ -385,6 +430,35 @@ class LocalEnvoyTestCase(unittest.IsolatedAsyncioTestCase):
                             }
                     }
                     self.assertEqual(await response.json(), expect_response)
+
+        # A state ID may hold any printable ASCII character, so the JS
+        # clients percent-encode the ID before interpolating it into
+        # this path (see `stateIdToRef` in `rbt/v1alpha1/index.ts`) and
+        # the filter decodes every escape back out. A `\` is left out
+        # because it is how a `/` within a single ID is spelled, which
+        # is why `StateRef.from_id` refuses it.
+        special_state_ids = [
+            f"a{chr(code)}b" for code in range(0x20, 0x7f) if chr(code) != '\\'
+        ]
+        for state_id in special_state_ids:
+            await General.ConstructorWriter(context, state_id)
+
+            status, body = await _post_exact_path(
+                url,
+                _reader_path(state_id),
+            )
+            self.assertEqual(status, 200, f"for {state_id!r}: {body!r}")
+
+        # Those 200s mean each decoded ID named the state the
+        # constructor above made, rather than merely some state,
+        # because a reader on a state that was never constructed
+        # answers 409 instead.
+        for state_id in special_state_ids:
+            status, body = await _post_exact_path(
+                url,
+                _reader_path(f"never-constructed{state_id}"),
+            )
+            self.assertEqual(status, 409, f"for {state_id!r}: {body!r}")
 
     async def test_remove_json_trailers_filter(self):
         """


### PR DESCRIPTION
Matt found some issue that `#` was silently accepted on the TS side and broke the WebSocket path. Make sure we escape everything properly and in the same way.