### PR TITLE
`bazel`: type check against first-party external repositories

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -68,6 +68,14 @@ build --aspects @mypy_integration//:mypy.bzl%mypy_aspect
 build --output_groups=+mypy
 build --@mypy_integration//:mypy_config=//:mypy.ini
 
+# A repository that depends on this one gets its Python code from an
+# external Bazel repository, but imports it under the same module names
+# the code has here (`reboot.*`, `rbt.*`, `log.*`). Naming that repository
+# here puts its sources on mypy's search path, so those imports resolve to
+# real types instead of `Any`. Errors inside them are reported by this
+# repository's own build, not by the depending one.
+build --@mypy_integration//:first_party_external_repos=com_github_reboot_dev_reboot
+
 # In Python there is the concept of a "namespace package", which is a single
 # package that's spread across multiple directories. This is useful for e.g. all
 # of the various Google libraries, that come in different PyPI packages like

--- a/bazel/bazel-mypy-integration_first_party_external_repos.patch
+++ b/bazel/bazel-mypy-integration_first_party_external_repos.patch
@@ -1,0 +1,158 @@
+diff --git a/BUILD b/BUILD
+--- a/BUILD
++++ b/BUILD
+@@ -1,3 +1,5 @@
++load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
++
+ package(default_visibility = ["//visibility:private"])
+ 
+ licenses(["notice"])  # MIT
+@@ -13,3 +15,12 @@
+     build_setting_default = "//:.mypy.ini",
+     visibility = ["//visibility:public"],
+ )
++
++# Comma-separated names of the external repositories whose Python sources are
++# first-party: their modules are resolved when type checking the main
++# repository, but errors within them are left to their own repository.
++string_flag(
++    name = "first_party_external_repos",
++    build_setting_default = "",
++    visibility = ["//visibility:public"],
++)
+diff --git a/mypy.bzl b/mypy.bzl
+--- a/mypy.bzl
++++ b/mypy.bzl
+@@ -2,6 +2,7 @@
+ 
+ load("@bazel_skylib//lib:shell.bzl", "shell")
+ load("@bazel_skylib//lib:sets.bzl", "sets")
++load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+ load("//:rules.bzl", "MyPyStubsInfo")
+ 
+ MyPyAspectInfo = provider(
+@@ -32,6 +33,9 @@
+         default = Label("//:mypy_config"),
+         allow_single_file = True,
+     ),
++    "_first_party_external_repos": attr.label(
++        default = Label("//:first_party_external_repos"),
++    ),
+ }
+ 
+ def _sources_to_cache_map_triples(srcs, is_aspect):
+@@ -51,11 +55,31 @@
+         ])
+     return triples_as_flat_list
+ 
+-def _is_external_dep(dep):
+-    return dep.label.workspace_root.startswith("external/")
++def _external_repo(file):
++    """The name of the external repository that `file` belongs to, or
++    `None` for a file of the main repository.
++
++    Bazel puts an external repository at `external/<repo>` directly beneath
++    the file's own root: the exec root for a source file, the
++    configuration's output directory for a generated one.
++    """
++    prefix = file.root.path + "/" if file.root.path else ""
++    if not file.path.startswith(prefix + "external/"):
++        return None
++    return file.path[len(prefix) + len("external/"):].split("/")[0]
+ 
+-def _is_external_src(src_file):
+-    return src_file.path.startswith("external/")
++def _external_repo_root(file, repo, is_aspect):
++    """The directory `repo` is rooted at, relative to the directory mypy is
++    invoked from.
++
++    That is the exec root for the aspect, and a binary's runfiles for
++    `mypy_test`, where `File.short_path` spells an external repository
++    `../<repo>`.
++    """
++    if not is_aspect:
++        return "../" + repo
++    prefix = file.root.path + "/" if file.root.path else ""
++    return prefix + "external/" + repo
+ 
+ def _extract_srcs(srcs):
+     direct_src_files = []
+@@ -68,7 +92,7 @@
+ def _extract_transitive_deps(deps):
+     transitive_deps = []
+     for dep in deps:
+-        if MyPyStubsInfo not in dep and PyInfo in dep and not _is_external_dep(dep):
++        if MyPyStubsInfo not in dep and PyInfo in dep:
+             transitive_deps.append(dep[PyInfo].transitive_sources)
+     return transitive_deps
+ 
+@@ -122,7 +146,25 @@
+ 
+     final_srcs_depset = depset(transitive = transitive_srcs_depsets +
+                                             [depset(direct = direct_src_files)])
+-    src_files = [f for f in final_srcs_depset.to_list() if not _is_external_src(f)]
++    repos_setting = ctx.attr._first_party_external_repos[BuildSettingInfo]
++    first_party_external_repos = [
++        repo
++        for repo in repos_setting.value.split(",")
++        if repo
++    ]
++
++    src_files = []
++    first_party_external_files = []
++    first_party_external_roots = {}
++    for f in final_srcs_depset.to_list():
++        repo = _external_repo(f)
++        if repo == None:
++            src_files.append(f)
++        elif repo in first_party_external_repos:
++            first_party_external_files.append(f)
++            root = _external_repo_root(f, repo, is_aspect)
++            first_party_external_roots[root] = True
++
+     if not src_files:
+         return None
+ 
+@@ -149,6 +191,7 @@
+     src_files = list(filtered_files.values())
+ 
+     mypypath_parts += [src_f.dirname for src_f in stub_files]
++    mypypath_parts += sorted(first_party_external_roots)
+     mypypath = ":".join(mypypath_parts)
+ 
+     # Ideally, a file should be passed into this rule. If this is an executable
+@@ -171,7 +214,10 @@
+     # Compose a list of the files needed for use. Note that aspect rules can use
+     # the project version of mypy however, other rules should fall back on their
+     # relative runfiles.
+-    runfiles = ctx.runfiles(files = src_files + stub_files + [mypy_config_file])
++    runfiles = ctx.runfiles(
++        files = src_files + first_party_external_files + stub_files +
++                [mypy_config_file],
++    )
+     if not is_aspect:
+         runfiles = runfiles.merge(ctx.attr._mypy_cli.default_runfiles)
+ 
+@@ -179,6 +225,13 @@
+         sets.make([f.root.path for f in src_files]),
+     )
+ 
++    # mypy only accepts a `--package-root` at or below the directory it is
++    # invoked from, and a `mypy_test`'s runfiles put an external repository
++    # above it.
++    package_roots = src_root_paths
++    if is_aspect:
++        package_roots = package_roots + sorted(first_party_external_roots)
++
+     ctx.actions.expand_template(
+         template = ctx.file._template,
+         output = exe,
+@@ -188,7 +241,7 @@
+             "{CACHE_MAP_TRIPLES}": " ".join(_sources_to_cache_map_triples(src_files, is_aspect)),
+             "{PACKAGE_ROOTS}": " ".join([
+                 "--package-root " + shell.quote(path or ".")
+-                for path in src_root_paths
++                for path in package_roots
+             ]),
+             "{SRCS}": " ".join([
+                 shell.quote(f.path) if is_aspect else shell.quote(f.short_path)

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -144,6 +144,7 @@ def repos():
         url = "https://github.com/bazel-contrib/bazel-mypy-integration/archive/refs/tags/0.5.0.tar.gz",
         patches = [
             "@com_github_reboot_dev_reboot//bazel:bazel-mypy-integration_avoid_duplicate_names.patch",
+            "@com_github_reboot_dev_reboot//bazel:bazel-mypy-integration_first_party_external_repos.patch",
         ],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
Our Bazel `mypy` integration threw away every dependency that lives in an external repository before it hands sources to `mypy`. That behavior is right for third-party code, since we don't want errors _inside_ e.g. gRPC's library to become errors for our project. However, as an unfortunate side-effect that means that _our usage_ of external code also isn't checkable - we must add many ignore-entries in `mypy.ini`.

While the trade-off seems right for third-party code, for our own first-party repos the better tradeoff would be the opposite: we're OK with a double-check of external repos, if that means that we get proper cross-repo type checks. This commit adds a patch to our `bazel-mypy-integration` to make that possible.

(Note `bazel-mypy-integration` has not cut a release since 2022, but its successor `rules_mypy`, also does not solve this problem and is built for Bzlmod, which we don't support yet)

The cross-repo checks this patch makes possible have caught several real bugs in our code; follow-on PRs in other repos will fix those.