### PR TITLE
Fix several Maestro test flakes

### DIFF
--- a/.claude/rules/github-prose-no-hard-wrap.md
+++ b/.claude/rules/github-prose-no-hard-wrap.md
@@ -1,0 +1,24 @@
+# Don't hard-wrap prose posted to GitHub
+
+Anything that goes into GitHub's web UI — pull request descriptions,
+issue bodies, and every comment or review reply on either — gets one
+long line per paragraph, with no hard line breaks. GitHub soft-wraps
+it to the reader's viewport.
+
+Commit messages are the opposite: hard-wrap their bodies at ~72
+columns, because they are read in terminals through `git log`.
+
+**Why:** A hard-wrapped paragraph renders ragged on GitHub, because
+the browser wraps the already-broken lines a second time at a width
+unrelated to the one they were broken at, leaving short uneven lines
+that get worse on a narrow viewport. A terminal does no wrapping of
+its own, so a commit message needs exactly the breaks the web UI
+should never receive.
+
+**How to apply:** When writing a PR description, an issue, or a
+comment, keep each paragraph on a single line however long it runs;
+tables, lists, headings and fenced code blocks still break as their
+own syntax requires. Take particular care when a PR description is
+drafted alongside a commit message — the two are governed by opposite
+rules, and it is easy to carry the commit message's wrapping into the
+PR body.

--- a/Dockerfile
+++ b/Dockerfile
@@ -710,6 +710,22 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
     && bash /tmp/maestro-install.sh \
     && rm /tmp/maestro-install.sh; \
     fi
+
+# Warm the npm cache with the packages `rbt generate` installs into a
+# project's `.rbt` directory, and with their dependencies. This
+# version must match the one `_check_or_install_npm_packages` asks for
+# in `reboot/cli/commands/generate.py`. When a test runs `rbt dev run`
+# against a fresh state directory it installs these packages, and a
+# warm cache lets it do that without a registry round-trip. A real
+# resolution is what walks the dependency graph, so this installs the
+# three into a throwaway prefix, leaving the whole closure in the
+# cache; it also fails the build if the pin stops resolving.
+ARG BUFBUILD_VERSION=1.10.1
+RUN npm install --prefix /tmp/npm-cache-warm \
+    @bufbuild/protoplugin@${BUFBUILD_VERSION} \
+    @bufbuild/protoc-gen-es@${BUFBUILD_VERSION} \
+    @bufbuild/protobuf@${BUFBUILD_VERSION} \
+    && rm -rf /tmp/npm-cache-warm
 USER root
 
 ###############################################################################

--- a/reboot/examples/bank-pydantic/frontend/mobile/.maestro/flow.yaml
+++ b/reboot/examples/bank-pydantic/frontend/mobile/.maestro/flow.yaml
@@ -16,11 +16,16 @@
 # does not render and so cannot label.
 appId: host.exp.exponent
 ---
-# Wait for the app to finish mounting before driving it.
+# Wait for the app to load and mount before driving it. The harness
+# starts this flow when Metro reports "Android Bundled", i.e. once the
+# bundle is built; the device then has to fetch it over the emulator's
+# user-mode NAT, parse ~900 modules in Hermes, and mount them. That
+# takes 0.7s on an idle emulator and minutes on one still finishing a
+# cold boot alongside Play Services, so budget for the slow case.
 - extendedWaitUntil:
     visible:
       id: "sign-in-button"
-    timeout: 30000
+    timeout: 180000
 
 # On a fresh Expo Go install, the first project open shows Expo Go's
 # onboarding "developer menu" bottom sheet over the app, and its scrim

--- a/reboot/examples/bank-pydantic/frontend/mobile/.tests/maestro_test.sh
+++ b/reboot/examples/bank-pydantic/frontend/mobile/.tests/maestro_test.sh
@@ -49,6 +49,23 @@ export ANDROID_HOME
 export ANDROID_SDK_ROOT="${ANDROID_HOME}"
 export PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/emulator:${HOME}/.maestro/bin:${PATH}"
 
+# Keep a degraded npm registry from consuming this test's budget.
+# `prefer-offline` takes any package already in the cache without
+# revalidating it against the registry, which covers the `.rbt`
+# packages the devcontainer image pre-caches; only what the cache
+# lacks is fetched at all. Those fetches are bounded three ways:
+# `fetch-timeout` (milliseconds) caps one attempt at a minute rather
+# than npm's five-minute default; `fetch-retries` is a count of
+# retries AFTER the first attempt, so three of them means four
+# attempts; and `fetch-retry-maxtimeout` caps the backoff between
+# attempts, which npm otherwise grows by a factor of ten up to a
+# minute. A wedged fetch therefore gives up after roughly five
+# minutes, well inside the fifteen a `large` test gets.
+export npm_config_prefer_offline=true
+export npm_config_fetch_timeout=60000
+export npm_config_fetch_retries=3
+export npm_config_fetch_retry_maxtimeout=20000
+
 # The long-running background processes redirect their output to these
 # files (so their detached children can't hold `bazel test`'s output
 # pipe open; see the emulator launch below). That redirection means a

--- a/reboot/examples/chat-room/frontend/mobile/.maestro/flow.yaml
+++ b/reboot/examples/chat-room/frontend/mobile/.maestro/flow.yaml
@@ -14,11 +14,16 @@
 # text) so they are precise about what they match.
 appId: host.exp.exponent
 ---
-# Wait for the app to finish mounting before driving it.
+# Wait for the app to load and mount before driving it. The harness
+# starts this flow when Metro reports "Android Bundled", i.e. once the
+# bundle is built; the device then has to fetch it over the emulator's
+# user-mode NAT, parse ~900 modules in Hermes, and mount them. That
+# takes 0.7s on an idle emulator and minutes on one still finishing a
+# cold boot alongside Play Services, so budget for the slow case.
 - extendedWaitUntil:
     visible:
       id: "message-input"
-    timeout: 30000
+    timeout: 180000
 
 # On a fresh Expo Go install, the first project open shows Expo Go's
 # onboarding developer-menu bottom sheet over the app, and its scrim

--- a/reboot/examples/chat-room/frontend/mobile/.tests/maestro_test.sh
+++ b/reboot/examples/chat-room/frontend/mobile/.tests/maestro_test.sh
@@ -48,6 +48,23 @@ export ANDROID_HOME
 export ANDROID_SDK_ROOT="${ANDROID_HOME}"
 export PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/emulator:${HOME}/.maestro/bin:${PATH}"
 
+# Keep a degraded npm registry from consuming this test's budget.
+# `prefer-offline` takes any package already in the cache without
+# revalidating it against the registry, which covers the `.rbt`
+# packages the devcontainer image pre-caches; only what the cache
+# lacks is fetched at all. Those fetches are bounded three ways:
+# `fetch-timeout` (milliseconds) caps one attempt at a minute rather
+# than npm's five-minute default; `fetch-retries` is a count of
+# retries AFTER the first attempt, so three of them means four
+# attempts; and `fetch-retry-maxtimeout` caps the backoff between
+# attempts, which npm otherwise grows by a factor of ten up to a
+# minute. A wedged fetch therefore gives up after roughly five
+# minutes, well inside the fifteen a `large` test gets.
+export npm_config_prefer_offline=true
+export npm_config_fetch_timeout=60000
+export npm_config_fetch_retries=3
+export npm_config_fetch_retry_maxtimeout=20000
+
 # The long-running background processes redirect their output to these
 # files (so their detached children can't hold `bazel test`'s output
 # pipe open; see the emulator launch below). That redirection means a


### PR DESCRIPTION
The `Test React Native mobile app (Maestro)` test was flaky; the robot traced it down to these issues:
1. The NPM registry was flaky, so some fetches stalled. The React Native tests run `rbt generate` which installs `npm` packages. The fix is to pre-fetch NPM packages into the cache once in the `Dockerfile`, then re-use that cache for all tests. Now there's only one fetch per test suite, so the odds of hitting an NPM registry issue are greatly reduced.
2. Under CPU contention, some deadlines were too tight. We loosen those deadlines somewhat.


While we're here, also tweak Claude's rules about how it writes PR descriptions/comments/... - that caused an issue in producing this PR.