### PR TITLE
Update Envoy, Istio, and various CLIs

### DIFF
--- a/.github/workflows/reboot_macos_environment.yml
+++ b/.github/workflows/reboot_macos_environment.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/0.11.13/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.12.11/install.sh | sh
           echo 'export PATH="$HOME/.local/bin:$PATH"' >> $HOME/.bash_profile
           export PATH="$HOME/.local/bin:$PATH"
           # TODO: See https://github.com/reboot-dev/mono/issues/2652.

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,11 @@ ARG TARGETARCH
 # Ubuntu Jammy does not have Python installed, so we use the ppa to install it.
 ARG PYTHON_VERSION=3.10
 
+# Transient DNS and connection failures on CI runners make single-shot
+# `apt` fetches flaky, so have `apt` retry each acquire a few times.
+# Every stage built from this one inherits the setting.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 # Install tzdata package to provide timezone files that tzlocal depends on.
 # Without this, /etc/localtime symlink to /usr/share/zoneinfo/Etc/UTC breaks,
 # causing "tzlocal() does not support non-zoneinfo timezones" errors.
@@ -763,6 +768,11 @@ ARG PYTHON_VERSION=3.10
 #            `build-essential` are only installed during a build stage, and are
 #            absent in the final runtime container - at the expense of a more
 #            complex Dockerfile.
+
+# This image starts from an upstream base rather than from
+# `respect-current-minimum`, so it needs the same `apt` retries.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 
 # Install `grpcurl`, which is very helpful for debugging. See:
 #   https://github.com/fullstorydev/grpcurl
-ARG GRPCURL_VERSION=1.9.2
+ARG GRPCURL_VERSION=1.9.4
 RUN if [ "${TARGETARCH}" = "amd64" ]; then \
     wget --tries=5 --waitretry=10 --retry-connrefused https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz \
     && tar -xvf ./grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz grpcurl \
@@ -166,7 +166,7 @@ ARG CLANG_VERSION
 ARG ENVOY_VERSION
 # Docker version format is Ubuntu-style:
 #    [epoch]:[version]-[revision]-[ubuntu-suffix]
-ARG DOCKER_VERSION=5:29.1.2-1~ubuntu.22.04~jammy
+ARG DOCKER_VERSION=5:29.8.0-1~ubuntu.22.04~jammy
 
 RUN apt-get update \
     # Install various prerequisite packages need for building as well as
@@ -255,7 +255,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Bazel.
-ARG BAZELISK_VERSION=v1.27.0
+ARG BAZELISK_VERSION=v1.29.0
 RUN wget --tries=5 --waitretry=10 --retry-connrefused -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-${TARGETARCH} \
     && chmod +x /usr/local/bin/bazel
 
@@ -292,8 +292,8 @@ RUN curl --retry 5 --retry-all-errors -fL https://istio.io/downloadIstio \
 
 # Install Skaffold as per instructions here:
 #   https://skaffold.dev/docs/install/
-# Latest version as of 2023-04-17.
-ARG SKAFFOLD_VERSION=2.3.1
+# Latest version as of 2026-09-09.
+ARG SKAFFOLD_VERSION=2.24.0
 RUN curl --retry 5 --retry-all-errors -fLo skaffold https://storage.googleapis.com/skaffold/releases/v${SKAFFOLD_VERSION}/skaffold-linux-${TARGETARCH} \
     && chmod +x skaffold && mv skaffold /usr/local/bin/
 
@@ -306,8 +306,8 @@ COPY .devcontainer/kustomize_wrapper.sh /usr/local/bin/kustomize
 # Install crane based on instructions here:
 #   https://github.com/google/go-containerregistry/tree/main/cmd/crane#install-from-releases
 # We use crane to move container images built by Bazel into Kubernetes clusters.
-# Latest version as of 2023-08-29.
-ARG CRANE_VERSION=0.16.1
+# Latest version as of 2026-09-09.
+ARG CRANE_VERSION=0.22.1
 RUN set -e; \
     if [ "${TARGETARCH}" = "amd64" ]; then \
     ARCH_SUFFIX="x86_64"; \
@@ -322,7 +322,7 @@ RUN set -e; \
 
 # Install the Groundcover CLI based on instructions here:
 #   https://github.com/groundcover-com/cli#from-the-binary-releases
-ARG GROUNDCOVER_VERSION=0.21.0
+ARG GROUNDCOVER_VERSION=0.22.14
 RUN curl --retry 5 --retry-all-errors -fSsL https://github.com/groundcover-com/cli/releases/download/v${GROUNDCOVER_VERSION}/groundcover_${GROUNDCOVER_VERSION}_linux_${TARGETARCH}.tar.gz -o /tmp/groundcover.tar.gz \
     && tar -zxf /tmp/groundcover.tar.gz -C /usr/bin \
     && chmod +x /usr/bin/groundcover
@@ -331,7 +331,7 @@ RUN curl --retry 5 --retry-all-errors -fSsL https://github.com/groundcover-com/c
 # Network projects. The non-sqlite build is deliberate: the `sqlite`
 # variants link against GLIBC 2.38, newer than this image (Ubuntu
 # Jammy, GLIBC 2.35).
-ARG ORY_VERSION=1.3.1
+ARG ORY_VERSION=1.3.3
 RUN set -e; \
     if [ "${TARGETARCH}" = "amd64" ]; then \
     ARCH_SUFFIX="64bit"; \
@@ -454,7 +454,7 @@ RUN wget --tries=5 --waitretry=10 --retry-connrefused https://github.com/bazelbu
 #   https://github.com/nodesource/distributions#installation-instructions
 # Note: We need this to install prettier.
 ARG NODE_MAJOR=20
-ARG NPM_VERSION=11.5.1
+ARG NPM_VERSION=11.19.1
 RUN mkdir -p /etc/apt/keyrings \
     && curl --retry 5 --retry-all-errors -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
@@ -467,7 +467,7 @@ RUN mkdir -p /etc/apt/keyrings \
 # rebuilding Bazel targets when their sources/dependencies change).
 ARG PRETTIER_VERSION=2.7.1
 ARG MARKDOWN_AUTODOCS_VERSION=1.0.133
-ARG IBAZEL_VERSION=0.26.10
+ARG IBAZEL_VERSION=0.28.0
 RUN npm install -g prettier@${PRETTIER_VERSION} markdown-autodocs@${MARKDOWN_AUTODOCS_VERSION} @bazel/ibazel@${IBAZEL_VERSION}
 
 # Install bash-completion so tab autocomplete works for git and other commands.
@@ -481,7 +481,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install bash-comple
 #  * `uv`, a fast Python package installer and resolver.
 #  * `py-spy`, the sampling profiler invoked by `_maybe_run_py_spy()`
 #    in `reboot/aio/monitoring.py`.
-RUN pip install yapf==0.40.2 mypy==1.18.1 isort==5.12.0 ruff==0.1.14 build==1.0.3 uv==0.9.18 py-spy==0.4.2
+RUN pip install yapf==0.40.2 mypy==1.18.1 isort==5.12.0 ruff==0.1.14 build==1.6.0 uv==0.12.11 py-spy==0.4.2
 
 # Install and setup fish (shell used on codespaces).
 # NOTE: We do this as it is done here:
@@ -523,7 +523,7 @@ RUN set -e; \
 
 # Install `aws-iam-authenticator`, which `kubectl` uses to authenticate with
 # AWS.
-ARG AWS_IAM_AUTHENTICATOR_VERSION=0.6.11
+ARG AWS_IAM_AUTHENTICATOR_VERSION=0.7.20
 RUN curl --retry 5 --retry-all-errors -fLo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_IAM_AUTHENTICATOR_VERSION}/aws-iam-authenticator_${AWS_IAM_AUTHENTICATOR_VERSION}_linux_${TARGETARCH} \
     && chmod +x ./aws-iam-authenticator \
     && mv ./aws-iam-authenticator /usr/local/bin/
@@ -532,7 +532,7 @@ RUN curl --retry 5 --retry-all-errors -fLo aws-iam-authenticator https://github.
 #
 # Even if we don't use Pulumi CLI directly as humans, the Pulumi SDK (used by
 # our code) requires that it is present.
-ARG PULUMI_VERSION=3.220.0
+ARG PULUMI_VERSION=3.261.0
 RUN set -e; \
     if [ "${TARGETARCH}" = "amd64" ]; then \
     ARCH_SUFFIX="x64"; \
@@ -551,7 +551,7 @@ RUN set -e; \
 # versions. (The latter is optional but enables the Python versions to be
 # cached in the Docker image).
 USER $UNAME
-RUN curl --retry 5 --retry-all-errors -LsSf https://astral.sh/uv/0.11.13/install.sh \
+RUN curl --retry 5 --retry-all-errors -LsSf https://astral.sh/uv/0.12.11/install.sh \
     -o /tmp/uv-install.sh \
     && sh /tmp/uv-install.sh \
     && rm /tmp/uv-install.sh \
@@ -586,14 +586,14 @@ RUN claude mcp add -s user chrome-devtools \
 USER root
 
 # Install Helm.
-ARG HELM_VERSION=3.15.4
+ARG HELM_VERSION=3.21.4
 RUN wget --tries=5 --waitretry=10 --retry-connrefused https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz \
     && tar --to-stdout -xvf ./helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz linux-${TARGETARCH}/helm > /usr/local/bin/helm \
     && rm ./helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz \
     && chmod +x /usr/local/bin/helm
 
 # Install the Helm chart-testing tool.
-ARG CHART_TESTING_VERSION=3.11.0
+ARG CHART_TESTING_VERSION=3.14.0
 RUN wget --tries=5 --waitretry=10 --retry-connrefused https://github.com/helm/chart-testing/releases/download/v${CHART_TESTING_VERSION}/chart-testing_${CHART_TESTING_VERSION}_linux_${TARGETARCH}.tar.gz \
     && tar --to-stdout -xvf ./chart-testing_${CHART_TESTING_VERSION}_linux_${TARGETARCH}.tar.gz ct > /usr/local/bin/ct \
     && rm ./chart-testing_${CHART_TESTING_VERSION}_linux_${TARGETARCH}.tar.gz \
@@ -608,14 +608,14 @@ RUN curl --retry 5 --retry-all-errors -fsSL https://get.pnpm.io/install.sh \
 
 # Install additional npm packages: `corepack` in order to get `yarn`, and the
 # Firebase CLI.
-ARG FIREBASE_VERSION=13.26.0
+ARG FIREBASE_VERSION=15.29.0
 RUN npm install -g corepack firebase-tools@${FIREBASE_VERSION} \
     && corepack enable
 
 # Install `kubectl krew` plugin manager, and the `resource-capacity`
 # plugin. We use a shared `KREW_ROOT` so that any user can run `kubectl
 # krew` without permission issues.
-ARG KREW_VERSION=v0.4.4
+ARG KREW_VERSION=v0.5.0
 ENV KREW_ROOT=/opt/krew
 RUN set -e; \
     case "${TARGETARCH}" in \
@@ -857,7 +857,7 @@ RUN set -e; \
     && ln -sf /opt/python/cp310-cp310/bin/pip /usr/local/bin/pip3
 
 # Install Bazel via Bazelisk.
-ARG BAZELISK_VERSION=v1.27.0
+ARG BAZELISK_VERSION=v1.29.0
 RUN set -e; \
     if [ "${TARGETARCH}" = "amd64" ]; then \
     ARCH_SUFFIX="amd64"; \
@@ -923,7 +923,7 @@ RUN dnf install -y nodejs && dnf clean all
 # Install uv for the builder user. We create a symlink in /usr/local/bin
 # so it's accessible on the PATH regardless of the user.
 USER builder
-RUN curl --retry 5 --retry-all-errors -LsSf https://astral.sh/uv/0.11.13/install.sh \
+RUN curl --retry 5 --retry-all-errors -LsSf https://astral.sh/uv/0.12.11/install.sh \
     -o /tmp/uv-install.sh \
     && sh /tmp/uv-install.sh \
     && rm /tmp/uv-install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,17 @@
 # The following ARGs must be defined before the first FROM, since they'll
 # parameterize a FROM.
 
-# Latest version as of 2025-02-06. Keep in sync with `ISTIO_VERSION` in
-# `infrastructure/clusters/resources/istio.py`.
-ARG ISTIO_VERSION=1.29.0
+# Latest version as of 2026-09-09. Keep in sync with the Istio version
+# that our Kubernetes clusters are deployed with, so that the
+# `istioctl` in this image speaks to a control plane of its own
+# version.
+ARG ISTIO_VERSION=1.30.4
 
-# This version should match `ENVOY_VERSION` in
-# `public/reboot/settings.py` and
-# `reboot/containers/reboot-base/Dockerfile`.
-ARG ENVOY_VERSION=1.38.2
+# This version should match `ENVOY_VERSION` in `reboot/settings.py`
+# and `reboot/containers/reboot-base/Dockerfile`. Istio 1.30.4 builds
+# its proxy from Envoy `1.38.4-dev`, so `1.38.4` is the released Envoy
+# patch that most closely matches the mesh proxies.
+ARG ENVOY_VERSION=1.38.4
 
 # Clang version used for C++ compilation on the host and in the
 # manylinux-builder container.

--- a/reboot/cli/commands/dev.py
+++ b/reboot/cli/commands/dev.py
@@ -693,7 +693,7 @@ async def check_local_envoy_mode(subprocesses: Subprocesses) -> None:
 
         # 'envoy --version' outputs something like:
         #  envoy  version:
-        #  <commit-sha>/1.38.2/Clean/RELEASE/BoringSSL
+        #  <commit-sha>/1.38.4/Clean/RELEASE/BoringSSL
         if ENVOY_VERSION not in stdout.decode():
             terminal.warn(
                 f"Reboot is tested with Envoy version '{ENVOY_VERSION}', "

--- a/reboot/containers/reboot-base/Dockerfile
+++ b/reboot/containers/reboot-base/Dockerfile
@@ -1,5 +1,5 @@
 # Keep in sync with top-level `Dockerfile` and `reboot/settings.py`.
-ARG ENVOY_VERSION=1.38.2
+ARG ENVOY_VERSION=1.38.4
 
 FROM envoyproxy/envoy:v${ENVOY_VERSION}
 

--- a/reboot/plugin/lib/install_envoy.sh
+++ b/reboot/plugin/lib/install_envoy.sh
@@ -18,10 +18,10 @@
 
 set -eu
 
-# Pinned Envoy version. Keep in sync with
-# `public/reboot/settings.py` (`ENVOY_VERSION`), which is the
-# library's source of truth for the resolver.
-ENVOY_VERSION="1.38.2"
+# Pinned Envoy version. Keep in sync with `reboot/settings.py`
+# (`ENVOY_VERSION`), which is the library's source of truth for the
+# resolver.
+ENVOY_VERSION="1.38.4"
 
 # `PLUGIN_DATA` is hardcoded rather than read from `$CLAUDE_PLUGIN_DATA`.
 # Claude Code only sets that env var when it runs something from a

--- a/reboot/settings.py
+++ b/reboot/settings.py
@@ -262,7 +262,7 @@ DATABASE_SUFFIX = "-sidecar"
 #
 # Keep in sync with top-level `Dockerfile` and
 # `reboot/containers/reboot-base/Dockerfile`.
-ENVOY_VERSION = '1.38.2'
+ENVOY_VERSION = '1.38.4'
 ENVOY_PROXY_IMAGE = f'envoyproxy/envoy:v{ENVOY_VERSION}'
 
 ENVVAR_LOCAL_ENVOY_USE_TLS = 'REBOOT_LOCAL_ENVOY_USE_TLS'

--- a/tests/reboot/react/test_200_websockets/test.py
+++ b/tests/reboot/react/test_200_websockets/test.py
@@ -3,17 +3,28 @@ import math
 import os
 import time
 from reboot.aio.external import ExternalContext
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.support.wait import WebDriverWait
 from tests.reboot.bank import SINGLETON_BANK_ID
 from tests.reboot.bank_rbt import Bank
 from tests.reboot.react.web_driver_runner import web_driver
+from typing import Optional
 
 # NOTE: as of the writing of this test we are only using Chrome but
 # when we test against other browsers we'll need to change this.
 CHROME_WEBSOCKET_LIMIT = 255
 ACCOUNTS = math.floor((CHROME_WEBSOCKET_LIMIT - 2) / 2)
+
+# How long the check that the "too many WebSockets" warning stays
+# absent while still under the limit keeps watching the console. A
+# bounded window is inherent to asserting that something does not
+# happen; every other wait in this test polls until its condition
+# holds and leaves Bazel's per-test timeout as the only backstop,
+# because a fixed in-test deadline is exactly what turns a loaded CI
+# runner into a failed test.
+WARNING_ABSENT_WINDOW_SECONDS = 5
+
+# How often the account wait reports what is still missing, so that a
+# stall is visible in the test log if Bazel ends the test.
+PROGRESS_REPORT_INTERVAL_SECONDS = 10
 
 
 async def test(context: ExternalContext, uri: str):
@@ -35,38 +46,73 @@ async def test(context: ExternalContext, uri: str):
                 os.path.dirname(__file__), 'bundle.js'
             ),
         ) as (driver, port):
-            # TODO: Make WebDriver emit any browser errors
-            # here so if the test times out below we can get
-            # a better idea of the problem.
             driver.get(f'http://127.0.0.1:{port}/')
-            wait = WebDriverWait(driver, 10)
+
+            def rendered_accounts() -> dict[str, str]:
+                """Returns the text of every rendered account element,
+                keyed by element ID, in a single round trip to the
+                browser."""
+                return driver.execute_script(
+                    'return Object.fromEntries('
+                    'Array.from('
+                    'document.querySelectorAll(\'h1[id^="Account "]\')'
+                    ').map((element) => [element.id, element.textContent])'
+                    ')'
+                )
+
+            def wait_for_accounts(count: int):
+                """Polls until every account from `1` to `count` shows
+                its balance, reporting the ones still missing at a
+                steady interval."""
+                missing = {f'{i + 1}' for i in range(count)}
+                last_report = time.perf_counter()
+                while True:
+                    rendered = rendered_accounts()
+                    # An account's balance is its initial deposit,
+                    # which is also its ID.
+                    missing = {
+                        account_id for account_id in missing if account_id
+                        not in (rendered.get(f'Account {account_id}') or '')
+                    }
+                    if len(missing) == 0:
+                        return
+                    now = time.perf_counter()
+                    if now - last_report >= PROGRESS_REPORT_INTERVAL_SECONDS:
+                        shown = sorted(missing, key=int)[:10]
+                        print(
+                            f'Still waiting for {len(missing)} of {count} '
+                            f'accounts to render; missing: {shown}'
+                            f'{" ..." if len(missing) > 10 else ""}'
+                        )
+                        last_report = now
+                    time.sleep(0.25)
 
             # We should be able to create `ACCOUNTS`
             # websockets without our `console.warn` showing
             # up, accounting for 1 for `useBank` mutations
             # and 1 for `useAssetsUnderManagement`.
-            for i in range(0, ACCOUNTS):
-                wait.until(
-                    expected_conditions.text_to_be_present_in_element(
-                        (By.ID, f'Account {i + 1}'),
-                        f'{i + 1}',
-                    )
-                )
+            wait_for_accounts(ACCOUNTS)
 
-            def look_for_warning():
+            def look_for_warning(*, window_seconds: Optional[float]) -> bool:
+                """Watches the browser console for the "too many
+                WebSockets" warning: for `window_seconds` when a window
+                is given, otherwise until the warning appears."""
                 snippet = (
                     'You can solve this by using HTTP/2'
                     ' which allows an unlimited'
                 )
-                deadline = time.perf_counter() + 5
-                while time.perf_counter() < deadline:
+                deadline = (
+                    time.perf_counter() +
+                    window_seconds if window_seconds is not None else None
+                )
+                while deadline is None or time.perf_counter() < deadline:
                     for line in driver.get_log('browser'):
                         if snippet in line['message']:
                             return True
                     time.sleep(0.1)
                 return False
 
-            if look_for_warning():
+            if look_for_warning(window_seconds=WARNING_ABSENT_WINDOW_SECONDS):
                 raise RuntimeError(
                     'Not expecting to see the console'
                     ' warning'
@@ -84,14 +130,13 @@ async def test(context: ExternalContext, uri: str):
                 loop,
             ).result()
 
-            found = look_for_warning()
-
-            # If we're using TLS then we _do not_ expect
-            # to see the warning and instead expect a
-            # timeout, otherwise we didn't see the warning
-            # we are expecting.
-            if not found and not uri.startswith('https:'):
-                raise RuntimeError('Expecting to see the console warning')
+            # Only cleartext WebSockets are subject to the browser's
+            # limit (over TLS it uses HTTP/2), so only the cleartext
+            # case has a warning to wait for: the extra account pushes
+            # the browser past its limit, and the warning follows once
+            # it tries to open the WebSockets for that account.
+            if not uri.startswith('https:'):
+                look_for_warning(window_seconds=None)
 
     # We execute the Selenium test in a separate thread to not block the
     # event loop.


### PR DESCRIPTION
A simple update to many of our dependencies: 
* we move Istio to `1.30.4` (its latest stable)
* we move Envoy to `1.38.4`, which is the closest match to that Istio's Envoy version.
* we update a bunch of CLIs in the `Dockerfile` to their latest versions.

While we're here, de-flake a test that caused a CI failure, and try to harden the `Dockerfile` against networking flakes.