### PR TITLE
Give field-less pydantic errors their `type` in TypeScript

### DIFF
--- a/reboot/cli/commands/dashboard.py
+++ b/reboot/cli/commands/dashboard.py
@@ -299,10 +299,10 @@ async def _open_when_serving(*, port: int) -> None:
         while not await _dashboard_reachable(port):
             await backoff()
 
-        while True:
+        viewers: Optional[list[str]] = None
+        while viewers is None:
             try:
                 viewers = await _viewers(dashboard_url)
-                break
             except Exception:
                 # Reachable means the proxy answers; the application
                 # behind it comes up moments later.

--- a/reboot/pydantic_schema_to_zod.py
+++ b/reboot/pydantic_schema_to_zod.py
@@ -291,7 +291,9 @@ def pydantic_to_zod(
         # Help 'mypy' narrow the type.
         input_model: Type[Model] = input
         input_fields = input_model.model_fields
-        if not input_fields:
+        # An error type always gets its `type` literal below, even with
+        # no fields: it is the discriminator of its method's errors.
+        if not input_fields and not is_error:
             output = 'z.object({})'
         else:
             output_fields = []

--- a/tests/reboot/pydantic_web/errors/index.tsx
+++ b/tests/reboot/pydantic_web/errors/index.tsx
@@ -44,6 +44,10 @@ const App = () => {
           case "AnotherError":
             setErrorResult(`AnotherError: ${error.reason}`);
             return;
+          case "EmptyError":
+            // `EmptyError` has no fields, only its `type`.
+            setErrorResult(`EmptyError`);
+            return;
           case "FailedPrecondition":
             // `FailedPrecondition` doesn't have additional details.
             setErrorResult(`FailedPrecondition`);
@@ -68,6 +72,12 @@ const App = () => {
         onClick={() => triggerError("another_error")}
       >
         Trigger AnotherError
+      </button>
+      <button
+        id="trigger-empty-error"
+        onClick={() => triggerError("empty_error")}
+      >
+        Trigger EmptyError
       </button>
       <button
         id="trigger-failed-precondition"

--- a/tests/reboot/pydantic_web/errors/servicer.py
+++ b/tests/reboot/pydantic_web/errors/servicer.py
@@ -3,6 +3,7 @@ from reboot.aio.auth.authorizers import allow
 from reboot.aio.contexts import WriterContext
 from tests.reboot.pydantic_web.errors.servicer_api import (
     AnotherError,
+    EmptyError,
     MyError,
     RaiseErrorRequest,
     State,
@@ -35,6 +36,8 @@ class TestServicer(Test.Servicer):
             raise Test.RaiseErrorAborted(
                 AnotherError(reason="This is another error reason")
             )
+        elif request.error_to_trigger == "empty_error":
+            raise Test.RaiseErrorAborted(EmptyError())
         elif request.error_to_trigger == "failed_precondition":
             raise Test.RaiseErrorAborted(FailedPrecondition())
         # Do not raise anything for "none".

--- a/tests/reboot/pydantic_web/errors/servicer_api.py
+++ b/tests/reboot/pydantic_web/errors/servicer_api.py
@@ -15,10 +15,15 @@ class AnotherError(Model):
     reason: str = Field(tag=1)
 
 
+class EmptyError(Model):
+    pass
+
+
 class RaiseErrorRequest(Model):
     error_to_trigger: Literal[
         "my_error",
         "another_error",
+        "empty_error",
         "failed_precondition",
         "none",
     ] = Field(tag=1)
@@ -34,7 +39,7 @@ TestMethods = Methods(
     raise_error=Writer(
         request=RaiseErrorRequest,
         response=None,
-        errors=[MyError, AnotherError],
+        errors=[MyError, AnotherError, EmptyError],
         mcp=None,
     ),
 )

--- a/tests/reboot/pydantic_web/errors/test.py
+++ b/tests/reboot/pydantic_web/errors/test.py
@@ -15,8 +15,9 @@ async def test(context: ExternalContext, uri: str):
     on the frontend. This tests:
     1. MyError (Pydantic) - should have message and code fields
     2. AnotherError (Pydantic) - should have reason field
-    3. FailedPrecondition (Protobuf) - standard protobuf error
-    4. No error case
+    3. EmptyError (Pydantic) - has no fields, only its type
+    4. FailedPrecondition (Protobuf) - standard protobuf error
+    5. No error case
     """
 
     def run_selenium_test():
@@ -84,6 +85,22 @@ async def test(context: ExternalContext, uri: str):
                 expected_conditions.text_to_be_present_in_element(
                     (By.ID, 'error-result'),
                     "AnotherError: This is another error reason",
+                )
+            )
+
+            # Test triggering `EmptyError`, which has no fields.
+            empty_error_button = wait.until(
+                expected_conditions.element_to_be_clickable(
+                    (By.ID, 'trigger-empty-error')
+                )
+            )
+            empty_error_button.click()
+
+            # Verify `EmptyError` is displayed.
+            wait.until(
+                expected_conditions.text_to_be_present_in_element(
+                    (By.ID, 'error-result'),
+                    "EmptyError",
                 )
             )
 


### PR DESCRIPTION
A declared error model with no fields, e.g. `class AdminAlreadyClaimedError(Model): pass`, was generated as `z.object({})`, skipping the `type: z.literal(...)` field that every other error gets. A method's errors are a `z.discriminatedUnion` on `type`, so zod threw "Invalid discriminated union option" as soon as the generated module loaded, and no page using it could render.

Error models now always get their `type` literal. The `pydantic_web/errors` test declares, raises, and checks a field-less `EmptyError`; without the fix the test fails to build.